### PR TITLE
Updated Development Environment which works with latest cider/nrepl

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,18 @@ Start [testrpc](https://github.com/ethereumjs/testrpc)
 ```bash
 testrpc --port 8549
 ```
-Start Clojurescript browser REPL
+
+Start Clojurescript browser REPL, first start a clojure repl
 ```
 lein repl
-(require 'figwheel-sidecar.repl-api)
-(figwheel-sidecar.repl-api/start-figwheel! (figwheel-sidecar.config/fetch-config))
-(figwheel-sidecar.repl-api/cljs-repl)
 ```
+
+When a clojure prompt is present, type:
+```
+(start-ui!)
+```
+The clojurescript repl will appear once you navigate to http:://localhost:6229
+
 
 See `ethlance.el` on how to run the above commands in Emacs via `ethlance-jack-in` and `ethlance-start`.
 

--- a/dev/cljs/user.cljs
+++ b/dev/cljs/user.cljs
@@ -1,0 +1,3 @@
+(ns ethlance.dev.user)
+
+(println "Setup Development Environment")

--- a/dev/ethlance/dev/user.clj
+++ b/dev/ethlance/dev/user.clj
@@ -1,0 +1,11 @@
+(ns ethlance.dev.user
+  (:require
+   [figwheel-sidecar.repl-api :as fw-repl]
+   [figwheel-sidecar.config :as fw-config]))
+
+
+(defn start-ui! []
+  (fw-repl/start-figwheel! (fw-config/fetch-config))
+  (fw-repl/cljs-repl))
+
+

--- a/ethlance.el
+++ b/ethlance.el
@@ -13,6 +13,15 @@
 ;;;; use M-x ethlance-jack-in to jack-in a Clojure and ClojureScript REPL
 ;;;;     M-x ethlance-start to start auto-compiling Solidity and testrpc
 ;;;;     M-x ethlance-quit to quit all processes
+;;;;
+;;;; Notes:
+;;;;
+;;;; testrpc has been replaced by ganache-cli, a workaround:
+;;;; - remove testrpc
+;;;; - install ganache-cli
+;;;; - run command as root `ln -s /usr/bin/ganache-cli /usr/bin/testrpc`
+;;;;
+;;;; TODO: Replace testrpc calls with ganache-cli calls.
 
 
 (defcustom ethlance-root
@@ -20,23 +29,27 @@
   "The root directory of the Ethlance repo.")
 
 (defun start-compile-solidity-auto ()
+  (message "Starting auto-compiling Solidity Smart Contracts")
   (start-process-shell-command "compile-solidity"
-                               "compile-solidity"
+                               "*compile-solidity*"
                                (concat "cd " ethlance-root " && " "lein auto compile-solidity")))
+
+
 (defun start-testrpc ()
-  (message "Start testrpc")
+  (message "Starting testrpc...")
   (start-process-shell-command "testrpc"
-                               "testrpc"
+                               "*testrpc*"
                                (concat "cd " ethlance-root " && "  "lein start-testrpc")))
 
+
 (defun stop-compile-solidity-auto ()
-  (message "Stop autocompiling Solidity Smart Contracts")
-  (when-let ((buf (get-buffer "compile-solidity")))
+  (message "Stopping auto-compiling Solidity Smart Contracts")
+  (when-let ((buf (get-buffer "*compile-solidity*")))
     (kill-buffer buf)))
 
 (defun stop-testrpc ()
-  (message "Stop testrpc")
-  (when-let ((buf (get-buffer "testrpc")))
+  (message "Stopping testrpc...")
+  (when-let ((buf (get-buffer "*testrpc*")))
     (kill-buffer buf)))
 
 (defun quit-cider (repl-buffer)
@@ -49,8 +62,10 @@
 
 (defun ethlance-jack-in* ()
   (message "Jack in REPL")
-  (find-file (concat ethlance-root "/project.clj"))
-  (cider-jack-in-clojurescript))
+  ;; Not Required: you can include project-dir in later version of cider
+  ;;(find-file (concat ethlance-root "/project.clj"))
+  (cider-jack-in-clojurescript `(:project-dir ,ethlance-root
+                                 :cljs-repl-type "figwheel")))
 
 (defun ethlance-jack-in ()
   (interactive)

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,6 @@
                  [bidi "2.0.14"]
                  [cljs-ajax "0.5.8"]
                  [cljs-react-material-ui "0.2.46"]
-                 [cljsjs/web3 "0.18.4-0"]
                  [cljsjs/bignumber "2.1.4-1"]
                  [cljsjs/linkify "2.1.4-0" :exclusions [cljsjs/react]]
                  [cljsjs/material-ui-chip-input "0.15.0-0"]
@@ -13,6 +12,7 @@
                  [cljsjs/react-truncate "2.0.3-0"]
                  [cljsjs/react-ultimate-pagination "0.8.0-0" :exclusions [cljsjs/react cljsjs/react-dom]]
                  [cljsjs/solidity-sha3 "0.4.1-0"]
+                 [cljsjs/web3 "0.18.4-0"]
                  [com.andrewmcveigh/cljs-time "0.4.0"]
                  [com.cemerick/url "0.1.1"]
                  [day8.re-frame/async-flow-fx "0.0.6"]
@@ -20,12 +20,12 @@
                  [kibu/pushy "0.3.6"]
                  [madvas.re-frame/google-analytics-fx "0.1.0"]
                  [madvas.re-frame/web3-fx "0.1.12"]
+                 [madvas/reagent-patched "0.6.1" :exclusions [cljsjs/react cljsjs/react-dom]]
                  [medley "0.8.3"]
                  [org.clojure/clojure "1.9.0-alpha10"]
                  [org.clojure/clojurescript "1.9.671"]
                  [print-foo-cljs "2.0.3"]
-                 [re-frame "0.9.2" :exclusions [reagent]]
-                 [madvas/reagent-patched "0.6.1" :exclusions [cljsjs/react cljsjs/react-dom]]]
+                 [re-frame "0.9.2" :exclusions [reagent]]]
 
   :plugins [[lein-auto "0.1.2"]
             [lein-cljsbuild "1.1.4"]
@@ -55,16 +55,21 @@
 
   :profiles
   {:dev
-   {:dependencies [[binaryage/devtools "0.8.3"]
-                   [com.cemerick/piggieback "0.2.1"]
-                   [figwheel-sidecar "0.5.8"]
-                   [org.clojure/tools.nrepl "0.2.11"]]
-    :plugins [[lein-figwheel "0.5.8"]]}}
+   {:source-paths ["src/clj" "dev"]
+    :dependencies [[com.cemerick/piggieback "0.2.2"]
+                   [figwheel "0.5.16"]
+                   [figwheel-sidecar "0.5.16"]
+                   [org.clojure/tools.nrepl "0.2.13"]
+                   [binaryage/devtools "0.9.10"]]
+    :plugins [[lein-figwheel "0.5.16"]]
+    :repl-options {:init-ns ethlance.dev.user
+                   :nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]
+                   :port 6230}}}
 
   :cljsbuild
   {:builds
    [{:id "dev"
-     :source-paths ["src/cljs"]
+     :source-paths ["src/cljs" "dev"]
      :figwheel {:on-jsload "ethlance.core/mount-root"}
      :compiler {:main ethlance.core
                 :output-to "resources/public/js/compiled/app.js"


### PR DESCRIPTION
Was having issues getting the dev environment working, so I opted to fix it up before I start further work.

- included ./dev/ethlance/dev/user.clj which has been assigned the
  user namespace for the development repl

- new command `(start-ui!)`, for starting the figwheel cljs repl
  - included piggieback

- updated figwheel sidecar to latest version
- updated nrepl to latest version

- included ./dev/cljs/user.cljs, could potentially load a dev mainnet
  from here, instead of manually.

- fixed up ethlance.el to work with latest versions of cider

- a bit of renaming for process buffers to keep with conventions

- Updated readme to reflect the new development command

- Tested on Ubuntu 18.10 with recent snapshots of cider