### PR TITLE
Add iframe provider polyfill to allow Ethlance to be used in iframe wallets

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -36,6 +36,7 @@
 
       ga('create', 'UA-21191392-11', 'auto');
     </script>
+    <script src="https://unpkg.com/@ethvault/iframe-provider-polyfill@0.1.4/dist/index.js" integrity="sha384-MGEYVJJ9mpRbqHLuHyg9xjmzCG3WPS0XCWf0lNF07q1NN6WUPzBdDMW/6LRRBhxQ" crossorigin="anonymous"></script>
     <script>ethlance.core.init();</script>
   </body>
 </html>


### PR DESCRIPTION
Add iframe provider polyfill to allow Ethlance to be used in iframe based wallets, e.g. ethvault.xyz