### PR TITLE
Redesign dev namespaces

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,8 +1,8 @@
-(ns ethlance.dev.user
+(ns user
   (:require
    [figwheel-sidecar.repl-api :as fig-repl]
    [figwheel-sidecar.config :as fig-config]))
- 
+
 
 
 (def help-msg "

--- a/project.clj
+++ b/project.clj
@@ -128,8 +128,7 @@
 
   :profiles
   {:dev
-   {:source-paths ["src" "test"
-                   "dev/clj" "dev/ui" "dev/shared" "dev/server"]
+   {:source-paths ["src" "test" "dev"]
     :resource-paths ["dev/resources"]
     :dependencies [[cider/piggieback "0.4.1"]
                    [org.clojure/tools.nrepl "0.2.13"]
@@ -139,17 +138,19 @@
                    [doo "0.1.11"]]
     :plugins [[lein-figwheel "0.5.19"]
               [lein-doo "0.1.10"]]
-    :repl-options {:init-ns ethlance.dev.user
+    :repl-options {:init-ns user
                    :nrepl-middleware [cider.piggieback/wrap-cljs-repl]
-                   :port 6450}}}
+                   ;; not fixing port by default so we can start multiple repl instances
+                   ;; :port 6450
+                   }}}
 
   :cljsbuild
   {:builds
    [{:id "dev-ui"
      :source-paths ["src" "test"
-                    "dev/ui" "dev/shared"]
+                    "dev/ui"]
      :figwheel {:on-jsload "district.ui.reagent-render/rerender"}
-     :compiler {:main cljs.user ;; ./dev/ui
+     :compiler {:main ethlance.ui.core
                 :output-to "resources/public/js/compiled/ethlance_ui.js"
                 :output-dir "resources/public/js/compiled/out-dev-ui"
                 :asset-path "/js/compiled/out-dev-ui"
@@ -160,9 +161,9 @@
 
     {:id "dev-server"
      :source-paths ["src" "test"
-                    "dev/server" "dev/shared"]
+                    "dev/server"]
      :figwheel true
-     :compiler {:main cljs.user ;; ./dev/server
+     :compiler {:main ethlance.server.core
                 :output-to "target/node/ethlance_server.js"
                 :output-dir "target/node/out-dev-server"
                 :target :nodejs
@@ -192,7 +193,7 @@
 
     {:id "test-ui"
      :source-paths ["src" "test"
-                    "dev/ui" "dev/shared"]
+                    "dev/ui"]
      :figwheel true
      :compiler {:main ethlance.ui.test-runner ;; ./test/ui
                 :output-to "dev/resources/public/js/compiled/test_runner.js"
@@ -203,7 +204,7 @@
 
     {:id "test-server"
      :source-paths ["src" "test"
-                    "dev/server" "dev/shared"]
+                    "dev/server"]
      :figwheel true
      :compiler {:main ethlance.server.test-runner ;; ./test/server
                 :output-to "target/node_test/test_runner.js"

--- a/src/ethlance/server/core.cljs
+++ b/src/ethlance/server/core.cljs
@@ -1,6 +1,6 @@
 (ns ethlance.server.core
   "Main entrypoint for an ethlance production server.
-  
+
   Notes:
 
   - For Development, ./dev/server/ethlance/server/user.cljs is the main entrypoint.
@@ -29,12 +29,16 @@
    [ethlance.server.db]
    [ethlance.server.ipfs]
    [ethlance.shared.smart-contracts-prod :as smart-contracts-prod]
+   [ethlance.shared.smart-contracts-qa :as smart-contracts-qa]
+   [ethlance.shared.smart-contracts-dev :as smart-contracts-dev]
 
    ;; Ethlance Libraries
    [ethlance.shared.graphql.schema :refer [graphql-schema]]
    [ethlance.server.graphql.resolver :refer [graphql-resolver-map]]
 
-   [ethlance.server.graphql.mutations.sign-in :as sign-in]))
+   [ethlance.server.graphql.mutations.sign-in :as sign-in]
+
+   [ethlance.shared.utils :as shared-utils]))
 
 (def graphql-config
   {:port 6200
@@ -46,6 +50,11 @@
    :field-resolver (build-default-field-resolver graphql-utils/gql-name->kw)
    :graphiql false})
 
+(def contracts-var
+  (condp = (shared-utils/get-environment)
+    "prod" #'smart-contracts-prod/smart-contracts
+    "qa" #'smart-contracts-qa/smart-contracts
+    "dev" #'smart-contracts-dev/smart-contracts))
 
 (def main-config
   {:web3 {:port 8549}
@@ -54,7 +63,7 @@
                  :write-events-into-file? true
                  :file-path "ethlance-events.log"}
 
-   :smart-contracts {:contracts-var #'smart-contracts-prod/smart-contracts
+   :smart-contracts {:contracts-var contracts-var
                      :print-gas-usage? false
                      :auto-mining? false}
 
@@ -62,7 +71,9 @@
 
    :ipfs {:host "http://127.0.0.1:5001"
           :endpoint "/api/v0"
-          :gateway "http://127.0.0.1:8080/ipfs"}})
+          :gateway "http://127.0.0.1:8080/ipfs"}
+   :logging {:level "info"
+             :console? true}})
 
 
 (defn -main [& args]

--- a/src/ethlance/shared/utils.clj
+++ b/src/ethlance/shared/utils.clj
@@ -1,0 +1,9 @@
+(ns ethlance.shared.utils)
+
+(defmacro get-environment []
+  (let [env (or (System/getenv "ETHLANCE_ENV") "dev")]
+    ;; Write to stderr instead of stdout because the cljs compiler
+    ;; writes stdout to the raw JS file.
+    (binding [*out* *err*]
+      (println "Building with environment:" env))
+    env))

--- a/src/ethlance/shared/utils.cljs
+++ b/src/ethlance/shared/utils.cljs
@@ -1,0 +1,2 @@
+(ns ethlance.shared.utils
+  (:require-macros [ethlance.shared.utils]))


### PR DESCRIPTION
Lay outs dev stuff like : 

- dev/user.clj with fns to start ui and server fig builders
- dev/server/cljs/user.cljs server repl utils (redeploy, generate-data, resync, ...)
- dev/ui/cljs/user.cljs ui repl utils (dispatch test events, ...)
- one server main (ethlance.server.core), and one ui main (ethlance.ui.core) with configs per env

Also adds per environment configuration