### PR TITLE
Graphql queries 251

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ smart_contracts_dev.cljs
 /resources/libs/node_modules/
 /resources/libs/yarn-error.log
 /resources/libs/yarn.lock
+ethlance.db

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,6 @@ help:
 	@echo "  dev-server              :: Run Development Node Server for Figwheel Server Build"
 	@echo "  repl                    :: Start CLJ Repl."
 	@echo "  --"
-	@echo "  fig-dev-all             :: Start and Watch Server and UI Builds."
 	@echo "  fig-dev-server          :: Start and watch Figwheel Server Build."
 	@echo "  fig-dev-ui              :: Start and watch Figwheel UI Build."
 	@echo "  --"
@@ -75,16 +74,12 @@ dev-server:
 	node target/node/ethlance_server.js
 
 
-fig-dev-all:
-	lein figwheel dev-server dev-ui
-
-
 fig-dev-server:
-	lein figwheel dev-server
+	lein with-profile +dev-server figwheel dev-server
 
 
 fig-dev-ui:
-	lein figwheel dev-ui
+	lein with-profile +dev-ui figwheel dev-ui
 
 
 clean:
@@ -141,7 +136,7 @@ test:
 
 
 travis-test:
-	sh ./scripts/run_test_runner.sh # Produces Correct Error Codes
+	sh ./scripts/run_test_runner.sh # Produces Correct Exit Codes
 
 
 run:
@@ -152,21 +147,18 @@ ipfs:
 	ipfs daemon
 
 
-# Environment setup for truffle
-TRUFFLE_SCRIPT_FILE := ./node_modules/truffle/build/cli.bundled.js
 deploy:
-	node $(TRUFFLE_SCRIPT_FILE) migrate --network $(ETHEREUM_NETWORK) --reset
+	npx truffle migrate --network $(ETHEREUM_NETWORK) --reset
 
 
 build-contracts:
-	node $(TRUFFLE_SCRIPT_FILE) compile
+	npx truffle compile
 
 
 # Environment setup for ganache-cli
-TESTNET_SCRIPT_FILE := ./node_modules/ganache-cli/cli.js
 TESTNET_PORT := 8549
 testnet:
-	node $(TESTNET_SCRIPT_FILE) -m district0x -p $(TESTNET_PORT) $(TESTNET_OPTIONS) -l 8000000
+	npx ganache-cli -m district0x -p $(TESTNET_PORT) $(TESTNET_OPTIONS) -l 8000000
 
 
 build-docs:
@@ -189,13 +181,10 @@ check:
 
 
 # Environment Setup for lessc, and less-watch-compiler
-LESS_WATCH_SCRIPT := ./node_modules/less-watch-compiler/dist/less-watch-compiler.js
 LESS_BIN_PATH := ./node_modules/less/bin
 PATH := $(LESS_BIN_PATH):$(PATH)
-
-
 watch-css:
-	node $(LESS_WATCH_SCRIPT) resources/public/less resources/public/css main.less
+	npx less-watch-compiler resources/public/less resources/public/css main.less
 
 
 build-css:

--- a/dev/server/cljs/user.cljs
+++ b/dev/server/cljs/user.cljs
@@ -1,46 +1,20 @@
 (ns cljs.user
-  "Development Entrypoint for CLJS-Server."
-  (:require [cljs-web3.eth :as web3-eth]
-            [district.server.db :as db]
-            [district.server.logging]
-            [district.server.smart-contracts :as contracts]
-            [district.server.web3 :refer [web3]]
-            [district.server.web3-events]
-            [district.shared.async-helpers :refer [promise->]]
-            [district.shared.error-handling :refer [try-catch try-catch-throw]]
-            [ethlance.server.core]
-            [ethlance.server.db :as ethlance-db]
-            [ethlance.server.syncer]
-            [ethlance.server.test-runner :as server.test-runner]
-            [ethlance.server.test-utils :as server.test-utils]
-            [ethlance.shared.smart-contracts-dev :as smart-contracts-dev]
-            [honeysql.core :as sql]
-            [mount.core :as mount]
-            [taoensso.timbre :as log]))
+  (:require 
+   [honeysql.core :as sql]
+   [mount.core :as mount]
+   [taoensso.timbre :as log]))
+
 
 (def sql-format
   "Shorthand for honeysql.core/format"
   sql/format)
 
+
 (def help-message "
   CLJS-Server Repl Commands:
 
   -- Development Lifecycle --
-  (start)                         ;; Starts the state components (reloaded workflow)
-  (stop)                          ;; Stops the state components (reloaded workflow)
-  (restart)                       ;; Restarts the state components (reloaded workflow)
-
-  -- Development Helpers --
-  (run-tests)                     ;; Run the Server Tests (:reset? reset the testnet snapshot)
-  (repopulate-database!)          ;; Resynchronize Smart Contract Events into the Database
-  (restart-graphql!)              ;; Restart/Reload GraphQL Schema and Resolvers
-
-  -- Instrumentation --
-  (enable-instrumentation!)       ;; Enable fspec instrumentation
-  (disable-instrumentation!)      ;; Disable fspec instrumentation
-
-  -- GraphQL Utilities --
-  (gql <query>)                   ;; Run GraphQL Query
+  /Nothing Here, Yet/
 
   -- Misc --
   (help)                          ;; Display this help message
@@ -48,120 +22,11 @@
 ")
 
 
-(def dev-graphql-config
-  (-> ethlance.server.core/graphql-config
-      (assoc :graphiql true)))
-
-
-(def dev-config
-  "Default district development configuration for mount components."
-  (-> ethlance.server.core/default-config
-      (merge {:logging {:level "debug" :console? true}})
-      (merge {:db {:path "./resources/ethlance.db"
-                   :opts {:memory false}}})
-      (update :smart-contracts merge {:contracts-var #'smart-contracts-dev/smart-contracts
-                                      :print-gas-usage? true
-                                      :auto-mining? true})
-      (assoc :graphql dev-graphql-config)))
-
-
-(defn start-sync
-  "Start the mount components."
-  []
-  (-> (mount/with-args dev-config)
-      mount/start))
-
-
-(defn start
-  "Start the mount components asychronously."
-  [& opts]
-  (.nextTick
-   js/process
-   (fn []
-     (apply start-sync opts))))
-
-
-(defn stop-sync
-  "Stop the mount components."
-  []
-  (mount/stop))
-
-
-(defn stop
-  [& opts]
-  (.nextTick
-   js/process
-   (fn []
-     (apply stop-sync opts))))
-
-(defn restart-sync
-  "Restart the mount components."
-  []
-  (stop-sync)
-  (start-sync))
-
-
-(defn restart
-  [& opts]
-  (.nextTick
-   js/process
-   (fn []
-     (apply restart-sync opts))))
-
-
-;; (defn run-tests-sync
-;;   "Run server tests synchronously on the dev server.
-
-;;   Optional Arguments
-
-;;   reset? - Reset the smart-contract deployment snapshot"
-;;   []
-;;   (log/info "Started Running Tests!")
-;;   (server.test-runner/run-all-tests)
-;;   (log/info "Finished Running Tests!"))
-
-
-;; (defn run-tests
-;;   "Runs the server tests asynchronously on the dev server.
-;;    Note: This will perform several smart contract redeployments with
-;;   test defaults."
-;;   []
-;;   (log/info "Running Server Tests Asynchronously...")
-;;   (.nextTick js/process run-tests-sync))
-
-(defn reset-testnet!
-  "Resets the testnet deployment snapshot for server tests."
-  []
-  (server.test-utils/reset-testnet!))
-
-
-(defn repopulate-database-sync!
-  "Purges the database, re-synchronizes the blockchain events, and
-  re-populates the database."
-  []
-  (log/info "Repopulating database...")
-  (log/debug "Stopping syncer and database...")
-  (mount/stop
-   #'ethlance.server.syncer/syncer
-   #'district.server.web3-events/web3-events
-   #'ethlance.server.db/ethlance-db)
-  (log/debug "Starting syncer and database...")
-  (mount/start
-   #'ethlance.server.db/ethlance-db
-   #'district.server.web3-events/web3-events
-   #'ethlance.server.syncer/syncer))
-
-
-(defn repopulate-database!
-  "Repopulate database asynchronously."
-  []
-  (.nextTick js/process repopulate-database-sync!))
-
-
 (defn help
   "Display a help message on development commands."
   []
   (println help-message))
+
 
 (defn -dev-main
   "Commandline Entry-point for node dev_server.js"

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -36,8 +36,8 @@ CLJ Repl Commands:
 
 (defn start-server! []
   (let [;; Ports are +1 of default figwheel config values
-        server-port (+ (server-port) 1)
-        nrepl-port (+ (nrepl-port) 1)
+        server-port (inc (server-port))
+        nrepl-port (inc (nrepl-port))
 
         config (-> (fig-config/fetch-config)
                    (set-server-port server-port)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,6 @@
 {
-  "name": "ethlance",
-  "version": "2.0.0-SNAPSHOT",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "@apollo/protobufjs": {
       "version": "1.0.3",
@@ -98,6 +96,114 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
+    "@sentry/apm": {
+      "version": "5.15.5",
+      "resolved": "https://registry.npmjs.org/@sentry/apm/-/apm-5.15.5.tgz",
+      "integrity": "sha512-2PyifsiQdvFEQhbL7tQnCKGLOO1JtZeqso3bc6ARJBvKxM77mtyMo/D0C2Uzt9sXCYiALhQ1rbB1aY8iYyglpg==",
+      "requires": {
+        "@sentry/browser": "5.15.5",
+        "@sentry/hub": "5.15.5",
+        "@sentry/minimal": "5.15.5",
+        "@sentry/types": "5.15.5",
+        "@sentry/utils": "5.15.5",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/hub": {
+          "version": "5.15.5",
+          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.15.5.tgz",
+          "integrity": "sha512-zX9o49PcNIVMA4BZHe//GkbQ4Jx+nVofqU/Il32/IbwKhcpPlhGX3c1sOVQo4uag3cqd/JuQsk+DML9TKkN0Lw==",
+          "requires": {
+            "@sentry/types": "5.15.5",
+            "@sentry/utils": "5.15.5",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/minimal": {
+          "version": "5.15.5",
+          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.15.5.tgz",
+          "integrity": "sha512-zQkkJ1l9AjmU/Us5IrOTzu7bic4sTPKCatptXvLSTfyKW7N6K9MPIIFeSpZf9o1yM2sRYdK7GV08wS2eCT3JYw==",
+          "requires": {
+            "@sentry/hub": "5.15.5",
+            "@sentry/types": "5.15.5",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/types": {
+          "version": "5.15.5",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.15.5.tgz",
+          "integrity": "sha512-F9A5W7ucgQLJUG4LXw1ZIy4iLevrYZzbeZ7GJ09aMlmXH9PqGThm1t5LSZlVpZvUfQ2rYA8NU6BdKJSt7B5LPw=="
+        },
+        "@sentry/utils": {
+          "version": "5.15.5",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.15.5.tgz",
+          "integrity": "sha512-Nl9gl/MGnzSkuKeo3QaefoD/OJrFLB8HmwQ7HUbTXb6E7yyEzNKAQMHXGkwNAjbdYyYbd42iABP6Y5F/h39NtA==",
+          "requires": {
+            "@sentry/types": "5.15.5",
+            "tslib": "^1.9.3"
+          }
+        }
+      }
+    },
+    "@sentry/browser": {
+      "version": "5.15.5",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.15.5.tgz",
+      "integrity": "sha512-rqDvjk/EvogfdbZ4TiEpxM/lwpPKmq23z9YKEO4q81+1SwJNua53H60dOk9HpRU8nOJ1g84TMKT2Ov8H7sqDWA==",
+      "requires": {
+        "@sentry/core": "5.15.5",
+        "@sentry/types": "5.15.5",
+        "@sentry/utils": "5.15.5",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/core": {
+          "version": "5.15.5",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.15.5.tgz",
+          "integrity": "sha512-enxBLv5eibBMqcWyr+vApqeix8uqkfn0iGsD3piKvoMXCgKsrfMwlb/qo9Ox0lKr71qIlZVt+9/A2vZohdgnlg==",
+          "requires": {
+            "@sentry/hub": "5.15.5",
+            "@sentry/minimal": "5.15.5",
+            "@sentry/types": "5.15.5",
+            "@sentry/utils": "5.15.5",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/hub": {
+          "version": "5.15.5",
+          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.15.5.tgz",
+          "integrity": "sha512-zX9o49PcNIVMA4BZHe//GkbQ4Jx+nVofqU/Il32/IbwKhcpPlhGX3c1sOVQo4uag3cqd/JuQsk+DML9TKkN0Lw==",
+          "requires": {
+            "@sentry/types": "5.15.5",
+            "@sentry/utils": "5.15.5",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/minimal": {
+          "version": "5.15.5",
+          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.15.5.tgz",
+          "integrity": "sha512-zQkkJ1l9AjmU/Us5IrOTzu7bic4sTPKCatptXvLSTfyKW7N6K9MPIIFeSpZf9o1yM2sRYdK7GV08wS2eCT3JYw==",
+          "requires": {
+            "@sentry/hub": "5.15.5",
+            "@sentry/types": "5.15.5",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/types": {
+          "version": "5.15.5",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.15.5.tgz",
+          "integrity": "sha512-F9A5W7ucgQLJUG4LXw1ZIy4iLevrYZzbeZ7GJ09aMlmXH9PqGThm1t5LSZlVpZvUfQ2rYA8NU6BdKJSt7B5LPw=="
+        },
+        "@sentry/utils": {
+          "version": "5.15.5",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.15.5.tgz",
+          "integrity": "sha512-Nl9gl/MGnzSkuKeo3QaefoD/OJrFLB8HmwQ7HUbTXb6E7yyEzNKAQMHXGkwNAjbdYyYbd42iABP6Y5F/h39NtA==",
+          "requires": {
+            "@sentry/types": "5.15.5",
+            "tslib": "^1.9.3"
+          }
+        }
+      }
+    },
     "@sentry/core": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@sentry/core/-/core-4.2.1.tgz",
@@ -128,18 +234,67 @@
       }
     },
     "@sentry/node": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-4.2.1.tgz",
-      "integrity": "sha512-2QJ0vJ1MzgQ/KFcdFIbBfWgtcnnEGuaBI3WnvaOd7I+stoCSHlSKgFjyVjmulI5uDOdRa58L7ZkJbjiP49VM9A==",
+      "version": "5.15.5",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.15.5.tgz",
+      "integrity": "sha512-BK0iTOiiIM0UnydLeT/uUBY1o1Sp85aqwaQRMfZbjMCsgXERLNGvzzV68FDH1cyC1nR6dREK3Gs8bxS4S54aLQ==",
       "requires": {
-        "@sentry/core": "4.2.1",
-        "@sentry/hub": "4.2.1",
-        "@sentry/types": "4.2.1",
-        "@sentry/utils": "4.2.1",
-        "cookie": "0.3.1",
-        "lsmod": "1.0.0",
-        "md5": "2.2.1",
-        "stack-trace": "0.0.10"
+        "@sentry/apm": "5.15.5",
+        "@sentry/core": "5.15.5",
+        "@sentry/hub": "5.15.5",
+        "@sentry/types": "5.15.5",
+        "@sentry/utils": "5.15.5",
+        "cookie": "^0.3.1",
+        "https-proxy-agent": "^4.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/core": {
+          "version": "5.15.5",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.15.5.tgz",
+          "integrity": "sha512-enxBLv5eibBMqcWyr+vApqeix8uqkfn0iGsD3piKvoMXCgKsrfMwlb/qo9Ox0lKr71qIlZVt+9/A2vZohdgnlg==",
+          "requires": {
+            "@sentry/hub": "5.15.5",
+            "@sentry/minimal": "5.15.5",
+            "@sentry/types": "5.15.5",
+            "@sentry/utils": "5.15.5",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/hub": {
+          "version": "5.15.5",
+          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.15.5.tgz",
+          "integrity": "sha512-zX9o49PcNIVMA4BZHe//GkbQ4Jx+nVofqU/Il32/IbwKhcpPlhGX3c1sOVQo4uag3cqd/JuQsk+DML9TKkN0Lw==",
+          "requires": {
+            "@sentry/types": "5.15.5",
+            "@sentry/utils": "5.15.5",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/minimal": {
+          "version": "5.15.5",
+          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.15.5.tgz",
+          "integrity": "sha512-zQkkJ1l9AjmU/Us5IrOTzu7bic4sTPKCatptXvLSTfyKW7N6K9MPIIFeSpZf9o1yM2sRYdK7GV08wS2eCT3JYw==",
+          "requires": {
+            "@sentry/hub": "5.15.5",
+            "@sentry/types": "5.15.5",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/types": {
+          "version": "5.15.5",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.15.5.tgz",
+          "integrity": "sha512-F9A5W7ucgQLJUG4LXw1ZIy4iLevrYZzbeZ7GJ09aMlmXH9PqGThm1t5LSZlVpZvUfQ2rYA8NU6BdKJSt7B5LPw=="
+        },
+        "@sentry/utils": {
+          "version": "5.15.5",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.15.5.tgz",
+          "integrity": "sha512-Nl9gl/MGnzSkuKeo3QaefoD/OJrFLB8HmwQ7HUbTXb6E7yyEzNKAQMHXGkwNAjbdYyYbd42iABP6Y5F/h39NtA==",
+          "requires": {
+            "@sentry/types": "5.15.5",
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "@sentry/types": {
@@ -364,6 +519,11 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-0.2.4.tgz",
       "integrity": "sha1-lLiBq3FyhtAV+iGeCPtmcJ3aWj0="
+    },
+    "agent-base": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
+      "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g=="
     },
     "ajv": {
       "version": "6.12.0",
@@ -611,8 +771,7 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-      "optional": true
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "asn1": {
       "version": "0.2.4",
@@ -1518,7 +1677,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
-      "optional": true,
       "requires": {
         "prr": "~1.0.1"
       }
@@ -2858,6 +3016,30 @@
         "sshpk": "^1.7.0"
       }
     },
+    "https-proxy-agent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
+      "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
+      "requires": {
+        "agent-base": "5",
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -2889,8 +3071,7 @@
     "image-size": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
-      "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
-      "optional": true
+      "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w="
     },
     "inflight": {
       "version": "1.0.6",
@@ -3318,6 +3499,11 @@
       "requires": {
         "yallist": "^3.0.2"
       }
+    },
+    "lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
     },
     "lsmod": {
       "version": "1.0.0",
@@ -3857,7 +4043,6 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "optional": true,
       "requires": {
         "asap": "~2.0.3"
       }
@@ -3874,8 +4059,7 @@
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-      "optional": true
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
     "psl": {
       "version": "1.7.0",

--- a/project.clj
+++ b/project.clj
@@ -71,7 +71,7 @@
                  [district0x/district-ui-component-input "1.0.0"]
                  [district0x/district-ui-component-notification "1.0.0"]
                  [district0x/district-ui-component-tx-button "1.0.0"]
-                 [district0x/district-ui-graphql "1.0.10"]
+                 [district0x/district-ui-graphql "1.0.11"]
                  [district0x/district-ui-logging "1.1.0"]
                  [district0x/district-ui-notification "1.0.1"]
                  [district0x/district-ui-now "1.0.2"]
@@ -151,7 +151,17 @@
     :plugins [[lein-figwheel "0.5.19"]
               [lein-doo "0.1.10"]]
     :repl-options {:init-ns user
-                   :nrepl-middleware [cider.piggieback/wrap-cljs-repl]}}}
+                   :nrepl-middleware [cider.piggieback/wrap-cljs-repl]}}
+
+   :dev-ui
+   {:figwheel {:nrepl-port 9000
+               :server-ip "0.0.0.0"
+               :server-port 6500}}
+
+   :dev-server
+   {:figwheel {:nrepl-port 9001
+               :server-ip "localhost"
+               :server-port 6501}}}
 
   :cljsbuild
   {:builds

--- a/project.clj
+++ b/project.clj
@@ -1,28 +1,28 @@
 (defproject district0x/ethlance "2.0.0-SNAPSHOT"
   :url "https://github.com/district0x/ethlance"
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [org.clojure/clojurescript "1.10.597"]
+                 [org.clojure/clojurescript "1.10.439"]
 
                  ;; General
                  [akiroz.re-frame/storage "0.1.4"]
-                 [camel-snake-kebab "0.4.0"]
-                 [cljs-web3-next "0.1.1"]
+                 [camel-snake-kebab "0.4.1"]
+                 [cljs-web3-next "0.1.3"]
                  [cljsjs/buffer "5.1.0-1"]
                  [cljsjs/d3 "5.12.0-0"]
                  [cljsjs/react-infinite "0.13.0-0"]
                  [flib/simplebar "5.0.7-SNAPSHOT"]
 
                  [com.andrewmcveigh/cljs-time "0.5.2"]
-                 [com.rpl/specter "1.1.2"]
-                 [com.taoensso/encore "2.116.0"]
+                 [com.rpl/specter "1.1.3"]
+                 [com.taoensso/encore "2.120.0"]
                  [com.taoensso/timbre "4.10.0"]
                  [district0x/bignumber "1.0.3"]
                  [cljsjs/bignumber "4.1.0-0"]
                  [district0x/error-handling "1.0.4"]
-                 [expound "0.7.2"]
+                 [expound "0.8.4"]
                  [funcool/cuerdas "2.2.0"]
-                 [garden "1.3.9"]
-                 [medley "1.2.0"]
+                 [garden "1.3.10"]
+                 [medley "1.3.0"]
                  [mount "0.1.16"]
                  [orchestra "2019.02.06-1"]
                  [org.clojars.mmb90/cljs-cache "0.1.4"]
@@ -30,8 +30,8 @@
                  [org.clojure/core.match "0.3.0"]
                  [org.clojure/tools.reader "1.3.2"]
                  [print-foo-cljs "2.0.3"]
-                 [re-frame "0.11.0-rc2"]
-                 [reagent "0.9.0-rc2"]
+                 [re-frame "0.12.0"]
+                 [reagent "0.10.0"]
                  ;; Hotfix: Fix until district-ui-graphql updates dependency
                  [day8.re-frame/forward-events-fx "0.0.6"]
 
@@ -39,7 +39,7 @@
                  [district0x/async-helpers "0.1.3"]
                  [district0x/district-cljs-utils "1.0.4"]
                  [district0x/district-encryption "1.0.1"]
-                 [district0x/district-format "1.0.7"]
+                 [district0x/district-format "1.0.8"]
                  [district0x/district-graphql-utils "1.0.10"]
                  [district0x/district-parsers "1.0.0"]
                  [district0x/district-sendgrid "1.0.1"]
@@ -49,10 +49,10 @@
                  ;; District Server Components
                  [district0x/district-server-config "1.0.1"]
                  [district0x/district-server-db "1.0.4"]
-                 [district0x/district-server-logging "1.0.5"]
+                 [district0x/district-server-logging "1.0.6"]
                  [district0x/district-server-middleware-logging "1.0.0"]
                  [district0x/district-server-smart-contracts "1.2.5"]
-                 [district0x/district-server-web3 "1.2.3"]
+                 [district0x/district-server-web3 "1.2.5"]
                  [district0x/district-server-web3-events "1.1.10"]
 
                  ;; UI Components
@@ -71,7 +71,7 @@
                  [district0x/district-ui-component-input "1.0.0"]
                  [district0x/district-ui-component-notification "1.0.0"]
                  [district0x/district-ui-component-tx-button "1.0.0"]
-                 [district0x/district-ui-graphql "1.0.11"]
+                 [district0x/district-ui-graphql "1.0.12"]
                  [district0x/district-ui-logging "1.1.0"]
                  [district0x/district-ui-notification "1.0.1"]
                  [district0x/district-ui-now "1.0.2"]
@@ -81,12 +81,12 @@
                  [district0x/district-ui-smart-contracts "1.0.8"]
                  [district0x/district-ui-web3 "1.3.2"]
                  [district0x/district-ui-web3-account-balances "1.0.2"]
-                 [district0x/district-ui-web3-accounts "1.0.6"]
+                 [district0x/district-ui-web3-accounts "1.0.7"]
                  [district0x/district-ui-web3-balances "1.0.2"]
                  [district0x/district-ui-web3-sync-now "1.0.3-2"]
-                 [district0x/district-ui-web3-tx "1.0.11"]
+                 [district0x/district-ui-web3-tx "1.0.12"]
                  [district0x/district-ui-web3-tx-id "1.0.1"]
-                 [district0x/district-ui-web3-tx-log "1.0.12"]
+                 [district0x/district-ui-web3-tx-log "1.0.13"]
                  [district0x/district-ui-window-size "1.0.1"]
                  [district0x/re-frame-ipfs-fx "1.1.1"]]
 
@@ -142,13 +142,14 @@
   {:dev
    {:source-paths ["src" "test" "dev"]
     :resource-paths ["resources" "dev/resources"]
-    :dependencies [[binaryage/devtools "0.9.10"]
-                   [cider/piggieback "0.4.2"]
+    :dependencies [[binaryage/devtools "1.0.1"]
+                   [cider/piggieback "0.5.0"]
                    [doo "0.1.11"]
-                   [figwheel "0.5.19"]
-                   [figwheel-sidecar "0.5.19"]
-                   [org.clojure/tools.nrepl "0.2.13"]]
-    :plugins [[lein-figwheel "0.5.19"]
+                   [figwheel "0.5.20"]
+                   [figwheel-sidecar "0.5.20"]
+                   [org.clojure/tools.nrepl "0.2.13"]
+                   [day8.re-frame/re-frame-10x "0.6.5"]]
+    :plugins [[lein-figwheel "0.5.20"]
               [lein-doo "0.1.10"]]
     :repl-options {:init-ns user
                    :nrepl-middleware [cider.piggieback/wrap-cljs-repl]}}
@@ -178,7 +179,9 @@
                 :optimizations :none
                 :source-map true
                 :source-map-timestamp true
-                :closure-defines {goog.DEBUG true}}}
+                :closure-defines {"re_frame.trace.trace_enabled_QMARK_" true
+                                  goog.DEBUG true}
+                :preloads [day8.re-frame-10x.preload]}}
 
     {:id "dev-server"
      :source-paths ["src/ethlance/server" "src/ethlance/shared" "dev/server/cljs"]

--- a/resources/public/less/component/error-message.less
+++ b/resources/public/less/component/error-message.less
@@ -1,0 +1,27 @@
+/// error-message.less -- Component for showing error messages when things don't work.
+
+
+.error-message {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  > .logo {
+    width: 64px;
+    height: 64px;
+  }
+
+  > .message {
+    padding: 1em;
+  }
+
+  > .show-button {
+    cursor: pointer;
+    text-decoration: underline;
+    
+  }
+
+  > .details {
+    padding: 1em;
+  }
+}

--- a/resources/public/less/component/info-message.less
+++ b/resources/public/less/component/info-message.less
@@ -1,0 +1,27 @@
+/// info-message.less -- Component for showing info messages when things don't work.
+
+
+.info-message {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  > .logo {
+    width: 64px;
+    height: 64px;
+  }
+
+  > .message {
+    padding: 1em;
+  }
+
+  > .show-button {
+    cursor: pointer;
+    text-decoration: underline;
+    
+  }
+
+  > .details {
+    padding: 1em;
+  }
+}

--- a/resources/public/less/component/pagination.less
+++ b/resources/public/less/component/pagination.less
@@ -1,0 +1,27 @@
+/// pagination.less -- Styling for the Pagination Component
+
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  > .ethlance-icon {
+    cursor: pointer;
+    
+    &.disabled {
+      cursor: not-allowed;
+      opacity: 0.3;
+      pointer-events: none;
+    }
+  }
+
+  > .range-label {
+    > .current-page , .num-pages {
+      padding: 0 0.5em;
+    }
+
+    > .of {
+
+    }
+  }
+}

--- a/resources/public/less/components.less
+++ b/resources/public/less/components.less
@@ -7,6 +7,7 @@
 @import "component/circle-button";
 @import "component/currency-input";
 @import "component/email-input";
+@import "component/error-message";
 @import "component/ethlance-logo";
 @import "component/icon";
 @import "component/inline-svg";

--- a/resources/public/less/components.less
+++ b/resources/public/less/components.less
@@ -16,6 +16,7 @@
 @import "component/mobile-search-filter";
 @import "component/mobile-sidebar";
 @import "component/modal";
+@import "component/pagination";
 @import "component/profile-image";
 @import "component/radio-select";
 @import "component/rating";

--- a/resources/public/less/components.less
+++ b/resources/public/less/components.less
@@ -10,6 +10,7 @@
 @import "component/error-message";
 @import "component/ethlance-logo";
 @import "component/icon";
+@import "component/info-message";
 @import "component/inline-svg";
 @import "component/loading-spinner";
 @import "component/mobile-search-filter";

--- a/src/ethlance/server/core.cljs
+++ b/src/ethlance/server/core.cljs
@@ -34,27 +34,32 @@
 
    ;; Ethlance Libraries
 
-   [ethlance.shared.utils :as shared-utils]
+   [ethlance.shared.utils :as shared-utils]))
 
 
-   ))
+(def environment (shared-utils/get-environment))
+
 
 (def graphql-config
   {:port 4000
-   :sign-in-secret "SECRET"})
+   :sign-in-secret "SECRET"
+   :graphiql (= environment "dev")})
+
 
 (def contracts-var
-  (condp = (shared-utils/get-environment)
+  (condp = environment
     "prod" #'smart-contracts-prod/smart-contracts
     "qa" #'smart-contracts-qa/smart-contracts
     "dev" #'smart-contracts-dev/smart-contracts))
 
+
 (def default-config
   {:web3 {:url "ws://127.0.0.1:8549"}
 
-   :web3-events {:events {:ethlance-issuer/arbiters-invited [:ethlance-issuer :ArbitersInvited {} {:from-block 0 :to-block "latest"}]
 
+   :web3-events {:events {:ethlance-issuer/arbiters-invited [:ethlance-issuer :ArbitersInvited {} {:from-block 0 :to-block "latest"}]
                           :standard-bounties/bounty-issued [:standard-bounties :BountyIssued {} {:from-block 0 :to-block "latest"}]
+
                           :standard-bounties/bounty-approvers-updated [:standard-bounties :BountyApproversUpdated {} {:from-block 0 :to-block "latest"}]
                           :standard-bounties/contribution-added [:standard-bounties :ContributionAdded {} {:from-block 0 :to-block "latest"}]
                           :standard-bounties/contribution-refunded [:standard-bounties :ContributionRefunded {} {:from-block 0 :to-block "latest"}]
@@ -83,6 +88,7 @@
                           :ethlance-jobs/candidate-accepted [:ethlance-jobs :CandidateAccepted {} {:from-block 0 :to-block "latest"}]
 
                           }
+
                  :crash-on-event-fail? true
                  :skip-past-events-replay? true
                  :write-events-into-file? true

--- a/src/ethlance/server/core.cljs
+++ b/src/ethlance/server/core.cljs
@@ -1,11 +1,5 @@
 (ns ethlance.server.core
-  "Main entrypoint for an ethlance production server.
-
-  Notes:
-
-  - For Development, ./dev/server/ethlance/server/user.cljs is the main entrypoint.
-
-  "
+  "Main entrypoint for the ethlance server."
   (:require
    [mount.core :as mount]
    [taoensso.timbre :as log]

--- a/src/ethlance/server/graphql/middlewares.cljs
+++ b/src/ethlance/server/graphql/middlewares.cljs
@@ -1,4 +1,4 @@
-(ns ethlance.server.middlewares
+(ns ethlance.server.graphql.middlewares
   (:require [district.shared.async-helpers :as async-helpers]
             [district.graphql-utils :as graphql-utils]
             [taoensso.timbre :as log]

--- a/src/ethlance/server/graphql/resolvers.cljs
+++ b/src/ethlance/server/graphql/resolvers.cljs
@@ -130,9 +130,9 @@
    (let [{:keys [:job-story/id] :as job-story} (graphql-utils/gql->clj root)]
      (log/debug "job-story->employer-feedback-resolver" {:job-story job-story})
      (db/get (-> user-feedback-query
-                 (sql-helpers/merge-where [:= id :JobStory.job-story/id]))))))
+                 (sql-helpers/merge-where [:= id :JobStory.job-story/id])
                  ;; TODO: add to-user-type is employer when user-feedback-query is fixed
-                 
+                 )))))
 
 (def ^:private arbiter-query {:select [:Arbiter.user/address
                                        :Arbiter.arbiter/bio
@@ -184,7 +184,7 @@
      (log/debug "feedback->to-user-type-resolver" feedback)
      (-> (sql-helpers/merge-where user-type-query [:= from-user-address :user/address])
          db/get
-         :type))))
+         :type ))))
 
 (def ^:private candidate-query
   {:select [[:User.user/address :user/address]
@@ -397,7 +397,7 @@
      (log/debug "job-story->invoices-resolver" {:job-story job-story :args args})
      (paged-query query limit offset))))
 
-(defn sign-in-mutation [_ input {:keys [:config]}]
+(defn sign-in-mutation [_ {:keys [:input]} {:keys [:config]}]
   "Graphql sign-in mutation. Given `data` and `data-signature`
   recovers user address. If successful returns a JWT containing the user address."
   (try-catch-throw
@@ -512,18 +512,18 @@
 (def resolvers-map {:Query {:user user-resolver
                             :userSearch user-search-resolver
                             :candidate candidate-resolver
-                            :candidateSearch candidate-search-resolver}
-                    :employer employer-resolver
-                    :employerSearch employer-search-resolver
-                    :arbiter arbiter-resolver
-                    :arbiterSearch arbiter-search-resolver
-                    :job job-resolver
-                    :jobStory job-story-resolver
-                    :invoice invoice-resolver
+                            :candidateSearch candidate-search-resolver
+                            :employer employer-resolver
+                            :employerSearch employer-search-resolver
+                            :arbiter arbiter-resolver
+                            :arbiterSearch arbiter-search-resolver
+                            :job job-resolver
+                            :jobStory job-story-resolver
+                            :invoice invoice-resolver}
                     :Job {:job_stories job->job-stories-resolver}
                     :JobStory {:jobStory_employerFeedback job-story->employer-feedback-resolver
-                                :jobStory_candidateFeedback job-story->candidate-feedback-resolver
-                                :jobStory_invoices job-story->invoices-resolver}
+                               :jobStory_candidateFeedback job-story->candidate-feedback-resolver
+                               :jobStory_invoices job-story->invoices-resolver}
                     :User {:user_languages user->languages-resolvers
                            :user_isRegisteredCandidate user->is-registered-candidate-resolver
                            :user_isRegisteredEmployer user->is-registered-employer-resolver

--- a/src/ethlance/server/graphql/resolvers.cljs
+++ b/src/ethlance/server/graphql/resolvers.cljs
@@ -130,9 +130,9 @@
    (let [{:keys [:job-story/id] :as job-story} (graphql-utils/gql->clj root)]
      (log/debug "job-story->employer-feedback-resolver" {:job-story job-story})
      (db/get (-> user-feedback-query
-                 (sql-helpers/merge-where [:= id :JobStory.job-story/id])
+                 (sql-helpers/merge-where [:= id :JobStory.job-story/id]))))))
                  ;; TODO: add to-user-type is employer when user-feedback-query is fixed
-                 )))))
+                 
 
 (def ^:private arbiter-query {:select [:Arbiter.user/address
                                        :Arbiter.arbiter/bio
@@ -184,7 +184,7 @@
      (log/debug "feedback->to-user-type-resolver" feedback)
      (-> (sql-helpers/merge-where user-type-query [:= from-user-address :user/address])
          db/get
-         :type ))))
+         :type))))
 
 (def ^:private candidate-query
   {:select [[:User.user/address :user/address]
@@ -397,7 +397,7 @@
      (log/debug "job-story->invoices-resolver" {:job-story job-story :args args})
      (paged-query query limit offset))))
 
-(defn sign-in-mutation [_ {:keys [:input]} {:keys [:config]}]
+(defn sign-in-mutation [_ input {:keys [:config]}]
   "Graphql sign-in mutation. Given `data` and `data-signature`
   recovers user address. If successful returns a JWT containing the user address."
   (try-catch-throw
@@ -512,18 +512,18 @@
 (def resolvers-map {:Query {:user user-resolver
                             :userSearch user-search-resolver
                             :candidate candidate-resolver
-                            :candidateSearch candidate-search-resolver
-                            :employer employer-resolver
-                            :employerSearch employer-search-resolver
-                            :arbiter arbiter-resolver
-                            :arbiterSearch arbiter-search-resolver
-                            :job job-resolver
-                            :jobStory job-story-resolver
-                            :invoice invoice-resolver}
+                            :candidateSearch candidate-search-resolver}
+                    :employer employer-resolver
+                    :employerSearch employer-search-resolver
+                    :arbiter arbiter-resolver
+                    :arbiterSearch arbiter-search-resolver
+                    :job job-resolver
+                    :jobStory job-story-resolver
+                    :invoice invoice-resolver
                     :Job {:job_stories job->job-stories-resolver}
                     :JobStory {:jobStory_employerFeedback job-story->employer-feedback-resolver
-                               :jobStory_candidateFeedback job-story->candidate-feedback-resolver
-                               :jobStory_invoices job-story->invoices-resolver}
+                                :jobStory_candidateFeedback job-story->candidate-feedback-resolver
+                                :jobStory_invoices job-story->invoices-resolver}
                     :User {:user_languages user->languages-resolvers
                            :user_isRegisteredCandidate user->is-registered-candidate-resolver
                            :user_isRegisteredEmployer user->is-registered-employer-resolver

--- a/src/ethlance/server/graphql/server.cljs
+++ b/src/ethlance/server/graphql/server.cljs
@@ -21,8 +21,8 @@
 (def makeExecutableSchema (aget (nodejs/require "graphql-tools") "makeExecutableSchema"))
 (def applyMiddleware (aget (nodejs/require "graphql-middleware") "applyMiddleware"))
 
-(declare start stop)
 
+(declare start stop)
 
 
 (defstate ^{:on-reload :noop} graphql

--- a/src/ethlance/server/graphql/server.cljs
+++ b/src/ethlance/server/graphql/server.cljs
@@ -4,7 +4,7 @@
             [district.shared.async-helpers :refer [promise->]]
             [ethlance.server.graphql.authorization :as authorization]
             [ethlance.server.graphql.resolvers :as resolvers]
-            [ethlance.server.middlewares :as middlewares]
+            [ethlance.server.graphql.middlewares :as middlewares]
             [ethlance.shared.graphql.schema :as schema]
             [mount.core :as mount :refer [defstate]]
             [cljs.reader :refer [read-string]]

--- a/src/ethlance/shared/graphql/schema.cljs
+++ b/src/ethlance/shared/graphql/schema.cljs
@@ -43,10 +43,10 @@
 
     candidateSearch(
       user_address: ID,
-      categoriesAnd: [String!],
-      categoriesOr: [String!],
-      skillsAnd: [String!],
-      skillsOr: [String!],
+      categoriesAnd: [String],
+      categoriesOr: [String],
+      skillsAnd: [String],
+      skillsOr: [String],
       professionalTitle: String,
       orderBy: CandidateListOrderBy,
       orderDirection: OrderDirection,
@@ -121,7 +121,8 @@
   }
 
   type Mutation {
-    signIn(input: SignInInput!): String!,
+
+    signIn(dataSignature: String!, data: String!): String!
     sendMessage(to: ID, text: String): Boolean!,
     raiseDispute(jobStory_id: Int!, text: String): Boolean!,
     resolveDispute(jobStory_id: Int!): Boolean!,
@@ -131,12 +132,9 @@
     updateArbiter(arbiter: ArbiterInput!): Boolean!,
     createJobProposal(job_id: Int!, text: String!, rate: Int!, rateCurrencyId: String!): Boolean!,
     replayEvents: Boolean!
+
   }
 
-  input SignInInput {
-    dataSignature: String!,
-    data: String!
-  }
 
   # User Types
 
@@ -167,7 +165,7 @@
     user_dateUpdated: Date
 
     \"List of languages the user speaks\"
-    user_languages: [String!]
+    user_languages: [String]
 
     \"Registration Checks\"
     user_isRegisteredCandidate: Boolean!
@@ -176,7 +174,7 @@
   }
 
   type UserList {
-    items: [User!]
+    items: [User]
     totalCount: Int
     endCursor: Int
     hasNextPage: Boolean
@@ -204,10 +202,10 @@
     candidate_professionalTitle: String
 
     \"Categories of Focused Work\"
-    candidate_categories: [String!]
+    candidate_categories: [String]
 
     \"Skills of the Candidate\"
-    candidate_skills: [String!]
+    candidate_skills: [String]
 
     candidate_rateCurrencyId: Keyword
 
@@ -221,7 +219,7 @@
   }
 
   type CandidateList {
-    items: [Candidate!]
+    items: [Candidate]
     totalCount: Int
     endCursor: String
     hasNextPage: Boolean
@@ -256,7 +254,7 @@
   }
 
   type EmployerList {
-    items: [Employer!]
+    items: [Employer]
     totalCount: Int
     endCursor: String
     hasNextPage: Boolean
@@ -291,7 +289,7 @@
   }
 
   type ArbiterList  {
-    items: [Arbiter!]
+    items: [Arbiter]
     totalCount: Int
     endCursor: String
     hasNextPage: Boolean
@@ -363,11 +361,7 @@
     job_reward: Int
     job_acceptedArbiterAddress: ID
     job_employerAddress: ID
-
     job_stories(limit: Int, offset: Int): JobStoryList
-
-
-
 
     ethlanceJob_id: Int
     ethlanceJob_estimatedLenght: Int
@@ -379,7 +373,7 @@
   }
 
   type JobList {
-    items: [Job!]
+    items: [Job]
     totalCount: Int
     endCursor: String
     hasNextPage: Boolean
@@ -421,7 +415,7 @@
 
     jobStory_dispute: Dispute
 
-    jobStory_invoices(limit: Int, offset: Int,): InvoiceList
+    jobStory_invoices(limit: Int, offset: Int): InvoiceList
 
     ethlanceJobStory_invitationMessage: Message
     ethlanceJobStory_proposalMessage: Message
@@ -430,7 +424,7 @@
   }
 
   type JobStoryList {
-    items: [JobStory!]
+    items: [JobStory]
     totalCount: Int
     endCursor: String
     hasNextPage: Boolean
@@ -466,11 +460,12 @@
   }
 
   type InvoiceList  {
-    items: [Invoice!]
+    items: [Invoice]
     totalCount: Int
     endCursor: String
     hasNextPage: Boolean
   }
+
 
   # Dispute Types
 
@@ -493,7 +488,6 @@
   }
 
 
-
   # Feedback Types
 
   type Feedback {
@@ -510,7 +504,7 @@
   }
 
   type FeedbackList {
-    items: [Feedback!]
+    items: [Feedback]
     totalCount: Int
     endCursor: String
     hasNextPage: Boolean

--- a/src/ethlance/shared/routes.cljs
+++ b/src/ethlance/shared/routes.cljs
@@ -14,14 +14,14 @@
              ["/jobs" :route.job/jobs]
              ["/jobs/new" :route.job/new] ;; general & bounty
              ["/jobs/contract/" :route.job/contract]
-             ["/jobs/contract/:index" :route.job/contract]
+             ["/jobs/contract/:id" :route.job/contract]
              ["/jobs/detail/" :route.job/detail]
-             ["/jobs/detail/:index" :route.job/detail]
+             ["/jobs/detail/:id" :route.job/detail]
              
              ;; Invoices
              ["/invoices/new" :route.invoice/new]
              ["/invoices/" :route.invoice/index]
-             ["/invoices/:index" :route.invoice/index]
+             ["/invoices/:id" :route.invoice/index]
 
              ;; Me
              ["/me" :route.me/index]

--- a/src/ethlance/ui/component/error_message.cljs
+++ b/src/ethlance/ui/component/error_message.cljs
@@ -1,0 +1,21 @@
+(ns ethlance.ui.component.error-message
+  (:require
+   [reagent.core :as r]
+   [taoensso.timbre :as log]))
+
+
+(defn c-error-message
+  "An error message component, displaying a error logo, along with an
+  error message and a 'show details' dropdown for additional info."
+  [message details]
+  (let [*open? (r/atom false)]
+    (log/error (str message " : " details))
+    (fn []
+      [:div.error-message
+       [:div.logo
+        [:img {:src "/images/svg/ethlance_spinner.svg"}]] ;; FIXME
+       [:div.message message]
+       (when details
+         [:div.show-button {:on-click #(swap! *open? not)} (if @*open? "Hide Details" "Show Details")])
+       (when @*open?
+         [:div.details (str details)])])))

--- a/src/ethlance/ui/component/info_message.cljs
+++ b/src/ethlance/ui/component/info_message.cljs
@@ -1,17 +1,17 @@
-(ns ethlance.ui.component.error-message
+(ns ethlance.ui.component.info-message
   (:require
    [reagent.core :as r]
    [taoensso.timbre :as log]))
 
 
-(defn c-error-message
-  "An error message component, displaying a error logo, along with an
-  error message and a 'show details' dropdown for additional info."
+(defn c-info-message
+  "An info message component, displaying a info logo, along with an
+  info message and a 'show details' dropdown for additional info."
   [message details]
   (let [*open? (r/atom false)]
-    (log/error (str message " : " details))
+    (log/info (str message " : " details))
     (fn []
-      [:div.error-message
+      [:div.info-message
        [:div.logo
         [:img {:src "/images/svg/ethlance_spinner.svg"}]] ;; FIXME
        [:div.message message]
@@ -20,4 +20,4 @@
           {:on-click #(swap! *open? not)}
           (if @*open? "Hide Details" "Show Details")])
        (when @*open?
-         [:div.details (str details)])])))
+         [:div.details details])])))

--- a/src/ethlance/ui/component/inline_svg.cljs
+++ b/src/ethlance/ui/component/inline_svg.cljs
@@ -8,7 +8,8 @@
   - https://stackoverflow.com/questions/24933430/img-src-svg-changing-the-fill-color
   "
   (:require
-   [reagent.core :as r]))
+   [reagent.core :as r]
+   [reagent.dom :as rdom]))
 
 
 (def *cached-svg-listing (atom {}))
@@ -150,7 +151,7 @@
 
           (when @*inline-svg
             (let [inline-svg @*inline-svg
-                  elnode (r/dom-node this)]
+                  elnode (rdom/dom-node this)]
               (when id (.setAttribute inline-svg "id" id))
               (when class (.setAttribute inline-svg "class" class))
               (when width (.setAttribute inline-svg "width" width))

--- a/src/ethlance/ui/component/pagination.cljs
+++ b/src/ethlance/ui/component/pagination.cljs
@@ -24,7 +24,6 @@
                limit
                offset
                set-offset-event]}]
-    (println (str limit " Of " offset))
     (let [current-page (-> offset (/ limit) ceil inc)
           num-pages (-> total-count (/ limit) ceil inc)
           prev-offset (- offset limit)

--- a/src/ethlance/ui/component/pagination.cljs
+++ b/src/ethlance/ui/component/pagination.cljs
@@ -1,0 +1,52 @@
+(ns ethlance.ui.component.pagination
+  (:require
+   [reagent.core :as r]
+   [re-frame.core :as re]
+   [district.parsers :refer [parse-int]]
+
+   ;; Ethlance Components
+   [ethlance.ui.component.icon :refer [c-icon]]))
+
+
+;; Math Functions
+(def ceil (aget js/Math "ceil"))
+(def floor (aget js/Math "floor"))
+(def abs (aget js/Math "abs"))
+
+
+(defn c-pagination
+  "Component for handling pagination wrt a given listing.
+
+  "
+  []
+  (fn [{:keys [total-count
+               has-next-page?
+               limit
+               offset
+               set-offset-event]}]
+    (println (str limit " Of " offset))
+    (let [current-page (-> offset (/ limit) ceil inc)
+          num-pages (-> total-count (/ limit) ceil inc)
+          prev-offset (- offset limit)
+          prev-offset (if (< prev-offset 0) 0 prev-offset)
+          next-offset (+ offset limit)
+          next-offset (if (>= next-offset total-count) offset next-offset)]
+      [:div.pagination
+       [c-icon
+        {:name :ic-arrow-left
+         :class [(when (= offset 0) "disabled")]
+         :color :secondary
+         :inline? false
+         :title "Go To Previous Page"
+         :on-click #(re/dispatch [set-offset-event prev-offset])}]
+       [:div.range-label
+        [:span.current-page current-page]
+        [:span.of "of"]
+        [:span.num-pages num-pages]]
+       [c-icon
+        {:name :ic-arrow-right
+         :class [(when (>= (+ offset limit) total-count) "disabled")]
+         :color :secondary
+         :inline? false
+         :title "Go To Next Page"
+         :on-click #(re/dispatch [set-offset-event next-offset])}]])))

--- a/src/ethlance/ui/component/pagination.cljs
+++ b/src/ethlance/ui/component/pagination.cljs
@@ -17,15 +17,24 @@
 (defn c-pagination
   "Component for handling pagination wrt a given listing.
 
+  Keyword Arguments:
+
+  total-count - Total count of the listing
+
+  limit - The current limit of the listing
+
+  offset - The current offset of the listing
+
+  set-offset-event - Event to dispatch to change the offset value.
   "
   []
   (fn [{:keys [total-count
-               has-next-page?
                limit
                offset
                set-offset-event]}]
-    (let [current-page (-> offset (/ limit) ceil inc)
-          num-pages (-> total-count (/ limit) ceil inc)
+    (let [total-count (or total-count 0)
+          current-page (-> offset (/ limit) ceil inc)
+          num-pages (-> total-count (/ limit) ceil)
           prev-offset (- offset limit)
           prev-offset (if (< prev-offset 0) 0 prev-offset)
           next-offset (+ offset limit)

--- a/src/ethlance/ui/component/scrollable.cljs
+++ b/src/ethlance/ui/component/scrollable.cljs
@@ -1,6 +1,7 @@
 (ns ethlance.ui.component.scrollable
   (:require
    [reagent.core :as r]
+   [reagent.dom :as rdom]
    [flib.simplebar]))
 
 
@@ -21,7 +22,7 @@
       
       :component-did-mount
       (fn [this]
-        (let [elnode (r/dom-node this)
+        (let [elnode (rdom/dom-node this)
               simplebar (js/SimpleBar. elnode (clj->js opts))]
           (reset! *instance simplebar)))
 

--- a/src/ethlance/ui/component/search_input.cljs
+++ b/src/ethlance/ui/component/search_input.cljs
@@ -2,6 +2,7 @@
   (:require
    [clojure.core.async :as async :refer [go go-loop <! >! chan close! put! timeout] :include-macros true]
    [reagent.core :as r]
+   [reagent.dom :as rdom]
    [taoensso.timbre :as log]
    [cuerdas.core :as string]
    
@@ -104,7 +105,7 @@
      {:display-name "ethlance-chip-search-input"
       :component-did-mount
       (fn [this]
-        (let [root-dom (r/dom-node this)
+        (let [root-dom (rdom/dom-node this)
               search-input (.querySelector root-dom ".search-input")]
           (.addEventListener
            search-input "blur"

--- a/src/ethlance/ui/config.cljs
+++ b/src/ethlance/ui/config.cljs
@@ -4,12 +4,13 @@
    ;; District UI Components
    [district.ui.component.router]
 
+   [ethlance.shared.graphql.schema :as graphql.schema]
    [ethlance.shared.routes]))
 
 
 (def general-config
   {:logging
-   {:level :debug
+   {:level :info
     :console? true}
 
    :reagent-render
@@ -22,12 +23,14 @@
     :scroll-top? true
     :html5? true}
 
-   ;; Default one, should be moved to per env config file
-   :graphql {:jwt-sign-secret "SECRET"}})
+   :graphql {:schema graphql.schema/schema
+             :url "http://localhost:4000/graphql"
+             :jwt-sign-secret "SECRET"}})
 
 
 (def development-config
   (-> general-config
+      (assoc-in [:logging :level] :debug)
       (assoc-in [:router :routes] ethlance.shared.routes/dev-routes)))
 
 

--- a/src/ethlance/ui/config.cljs
+++ b/src/ethlance/ui/config.cljs
@@ -24,7 +24,8 @@
     :html5? true}
 
    :graphql {:schema graphql.schema/schema
-             :url "http://localhost:4000/graphql"
+             ;; :url "http://localhost:4000/graphql"
+             :url "http://192.168.0.111:4000/graphql"
              :jwt-sign-secret "SECRET"}})
 
 

--- a/src/ethlance/ui/core.cljs
+++ b/src/ethlance/ui/core.cljs
@@ -5,18 +5,19 @@
    [taoensso.timbre :as log]
 
    ;; District UI Components
+   [district.ui.component.router]
+   [district.ui.graphql]
+   [district.ui.logging]
    [district.ui.reagent-render]
    [district.ui.router]
-   [district.ui.component.router]
-   [district.ui.logging]
 
    ;; Ethlance
    [ethlance.ui.config :as ui.config]
-   [ethlance.ui.pages]
-   [ethlance.ui.util.injection :as util.injection]
-   [ethlance.ui.events]
    [ethlance.ui.effects]
-   [ethlance.ui.subscriptions]))
+   [ethlance.ui.events]
+   [ethlance.ui.pages]
+   [ethlance.ui.subscriptions]
+   [ethlance.ui.util.injection :as util.injection]))
 
 
 (enable-console-print!)

--- a/src/ethlance/ui/effects.cljs
+++ b/src/ethlance/ui/effects.cljs
@@ -13,5 +13,5 @@
                           :from from})
                 (fn [err result]
                   (if err
-                    (re-frame/dispatch (conj on-error err))
-                    (re-frame/dispatch (conj on-success (.-result result)))))))))
+                    (re/dispatch (conj on-error err))
+                    (re/dispatch (conj on-success (.-result result)))))))))

--- a/src/ethlance/ui/events.cljs
+++ b/src/ethlance/ui/events.cljs
@@ -80,8 +80,8 @@
                ethlance.ui.page.new-invoice.events/state-key
                ethlance.ui.page.new-invoice.events/state-default)]
 
-    ;; Main Events
-    ;; /Nothing here, yet/
+               ;; Main Events
+               ;; /Nothing here, yet/
     {:db new-db
      ;; Initialize Forwarded FX Events
      :dispatch-n forwarded-events

--- a/src/ethlance/ui/page/arbiters.cljs
+++ b/src/ethlance/ui/page/arbiters.cljs
@@ -132,18 +132,16 @@
                        :arbiter/bio
                        :arbiter/fee]]
               :total-count
-              :end-cursor
-              :has-next-page]]]}])
+              :end-cursor]]]}])
         *limit (re/subscribe [:page.arbiters/limit])
         *offset (re/subscribe [:page.arbiters/offset])]
     (fn []
       (let [{arbiter-search   :arbiter-search
              preprocessing?   :graphql/preprocessing?
              loading?         :graphql/loading?
-             errors           :graphql/errors
-             total-count      :total-count
-             has-next-page?   :has-next-page} @*arbiter-listing-query
-            arbiter-listing (-> arbiter-search :items)]
+             errors           :graphql/errors} @*arbiter-listing-query
+            {arbiter-listing  :items
+             total-count      :total-count} arbiter-search]
         [:<>
          (cond
            ;; Errors?
@@ -168,7 +166,6 @@
          (when (seq arbiter-listing)
            [c-pagination
             {:total-count total-count
-             :has-next-page? has-next-page?
              :limit @*limit
              :offset @*offset
              :set-offset-event :page.arbiters/set-offset}])]))))

--- a/src/ethlance/ui/page/arbiters.cljs
+++ b/src/ethlance/ui/page/arbiters.cljs
@@ -5,15 +5,20 @@
    [re-frame.core :as re]
    [taoensso.timbre :as log]
    [district.ui.component.page :refer [page]]
+   [district.ui.graphql.subs :as gql]
 
    [ethlance.shared.enumeration.currency-type :as enum.currency]
    [ethlance.shared.constants :as constants]
 
    ;; Ethlance Components
    [ethlance.ui.component.currency-input :refer [c-currency-input]]
+   [ethlance.ui.component.error-message :refer [c-error-message]]
+   [ethlance.ui.component.info-message :refer [c-info-message]]
    [ethlance.ui.component.inline-svg :refer [c-inline-svg]]
+   [ethlance.ui.component.loading-spinner :refer [c-loading-spinner]]
    [ethlance.ui.component.main-layout :refer [c-main-layout]]
    [ethlance.ui.component.mobile-search-filter :refer [c-mobile-search-filter]]
+   [ethlance.ui.component.pagination :refer [c-pagination]]
    [ethlance.ui.component.profile-image :refer [c-profile-image]]
    [ethlance.ui.component.radio-select :refer [c-radio-select c-radio-search-filter-element]]
    [ethlance.ui.component.rating :refer [c-rating]]
@@ -95,7 +100,8 @@
 
 
 (defn c-arbiter-element
-  [arbiter]
+  [{:keys [:user/address
+           :arbiter/bio]}]
   [:div.arbiter-element
    [:div.profile
     [:div.profile-image [c-profile-image {}]]
@@ -116,11 +122,56 @@
 
 
 (defn c-arbiter-listing []
-  [:<>
-   (doall
-    (for [arbiter (range 10)]
-      ^{:key (str "arbiter-" arbiter)}
-      [c-arbiter-element arbiter]))])
+  (let [*arbiter-listing-query
+        (re/subscribe
+         [::gql/query
+          {:queries
+           [[:arbiter-search
+             {:limit 10}
+             [[:items [:user/address
+                       :arbiter/bio
+                       :arbiter/fee]]
+              :total-count
+              :end-cursor
+              :has-next-page]]]}])
+        *limit (re/subscribe [:page.arbiters/limit])
+        *offset (re/subscribe [:page.arbiters/offset])]
+    (fn []
+      (let [{arbiter-search   :arbiter-search
+             preprocessing?   :graphql/preprocessing?
+             loading?         :graphql/loading?
+             errors           :graphql/errors
+             total-count      :total-count
+             has-next-page?   :has-next-page} @*arbiter-listing-query
+            arbiter-listing (-> arbiter-search :items)]
+        [:<>
+         (cond
+           ;; Errors?
+           (seq errors)
+           [c-error-message "Failed to process GraphQL" (pr-str errors)]
+
+           ;; Loading?
+           (or preprocessing? loading?)
+           [c-loading-spinner]
+
+           ;; Empty?
+           (empty? arbiter-listing)
+           [c-info-message "No Arbiters"]
+
+           :else
+           (doall
+            (for [arbiter arbiter-listing]
+              ^{:key (str "arbiter-" (hash arbiter))}
+              [c-arbiter-element arbiter])))
+
+         ;; Pagination
+         (when (seq arbiter-listing)
+           [c-pagination
+            {:total-count total-count
+             :has-next-page? has-next-page?
+             :limit @*limit
+             :offset @*offset
+             :set-offset-event :page.arbiters/set-offset}])]))))
 
 
 (defmethod page :route.user/arbiters []

--- a/src/ethlance/ui/page/arbiters/events.cljs
+++ b/src/ethlance/ui/page/arbiters/events.cljs
@@ -11,7 +11,9 @@
 
 (def state-key :page.arbiters)
 (def state-default
-  {:skills #{}
+  {:offset 0
+   :limit 10
+   :skills #{}
    :category constants/category-default
    :feedback-min-rating 1
    :feedback-max-rating 5
@@ -44,6 +46,8 @@
 
 
 (re/reg-event-fx :page.arbiters/initialize-page initialize-page)
+(re/reg-event-fx :page.arbiters/set-offset (create-assoc-handler :offset))
+(re/reg-event-fx :page.arbiters/set-limit (create-assoc-handler :limit))
 (re/reg-event-fx :page.arbiters/set-skills (create-assoc-handler :skills))
 (re/reg-event-fx :page.arbiters/add-skill add-skill)
 (re/reg-event-fx :page.arbiters/set-category (create-assoc-handler :category))

--- a/src/ethlance/ui/page/arbiters/subscriptions.cljs
+++ b/src/ethlance/ui/page/arbiters/subscriptions.cljs
@@ -11,7 +11,8 @@
 ;;
 ;; Registered Subscriptions
 ;;
-
+(re/reg-sub :page.arbiters/offset (create-get-handler :offset))
+(re/reg-sub :page.arbiters/limit (create-get-handler :limit))
 (re/reg-sub :page.arbiters/skills (create-get-handler :skills))
 (re/reg-sub :page.arbiters/category (create-get-handler :category))
 (re/reg-sub :page.arbiters/feedback-max-rating (create-get-handler :feedback-max-rating))

--- a/src/ethlance/ui/page/candidates.cljs
+++ b/src/ethlance/ui/page/candidates.cljs
@@ -72,7 +72,8 @@
           :default-search-text "Search Countries"}]]])))
 
 
-(defn c-candidate-search-filter []
+(defn c-candidate-search-filter
+  []
   [:div.search-filter
    [cf-candidate-search-filter]])
 

--- a/src/ethlance/ui/page/candidates.cljs
+++ b/src/ethlance/ui/page/candidates.cljs
@@ -12,6 +12,7 @@
 
    ;; Ethlance Components
    [ethlance.ui.component.currency-input :refer [c-currency-input]]
+   [ethlance.ui.component.error-message :refer [c-error-message]]
    [ethlance.ui.component.inline-svg :refer [c-inline-svg]]
    [ethlance.ui.component.loading-spinner :refer [c-loading-spinner]]
    [ethlance.ui.component.main-layout :refer [c-main-layout]]
@@ -105,6 +106,7 @@
          [::gql/query
           {:queries
            [[:candidate-search
+             {:limit 10}
              [[:items [:user/address :candidate/skills]]
               :total-count
               :end-cursor
@@ -112,10 +114,14 @@
     (fn []
       (let [{candidate-search :candidate-search
              preprocessing?   :graphql/preprocessing?
-             loading?         :graphql/loading?} @*candidate-listing-query]
+             loading?         :graphql/loading?
+             errors           :graphql/errors} @*candidate-listing-query]
         (println @*candidate-listing-query)
         [:<>
          (cond
+           (seq errors)
+           [c-error-message "Failed to process GraphQL" errors]
+
            (or preprocessing? loading?)
            [c-loading-spinner]
            

--- a/src/ethlance/ui/page/candidates/events.cljs
+++ b/src/ethlance/ui/page/candidates/events.cljs
@@ -11,7 +11,9 @@
 
 (def state-key :page.candidates)
 (def state-default
-  {:skills #{}
+  {:offset 0
+   :limit 10
+   :skills #{}
    :category constants/category-default
    :feedback-min-rating 1
    :feedback-max-rating 5
@@ -42,6 +44,8 @@
 
 
 (re/reg-event-fx :page.candidates/initialize-page initialize-page)
+(re/reg-event-fx :page.candidates/set-offset (create-assoc-handler :offset))
+(re/reg-event-fx :page.candidates/set-limit (create-assoc-handler :limit))
 (re/reg-event-fx :page.candidates/set-skills (create-assoc-handler :skills))
 (re/reg-event-fx :page.candidates/add-skill add-skill)
 (re/reg-event-fx :page.candidates/set-category (create-assoc-handler :category))

--- a/src/ethlance/ui/page/candidates/subscriptions.cljs
+++ b/src/ethlance/ui/page/candidates/subscriptions.cljs
@@ -12,6 +12,8 @@
 ;; Registered Subscriptions
 ;;
 
+(re/reg-sub :page.candidates/offset (create-get-handler :offset))
+(re/reg-sub :page.candidates/limit (create-get-handler :limit))
 (re/reg-sub :page.candidates/skills (create-get-handler :skills))
 (re/reg-sub :page.candidates/category (create-get-handler :category))
 (re/reg-sub :page.candidates/feedback-max-rating (create-get-handler :feedback-max-rating))

--- a/src/ethlance/ui/page/employers/events.cljs
+++ b/src/ethlance/ui/page/employers/events.cljs
@@ -11,7 +11,9 @@
 ;; Page State
 (def state-key :page.employers)
 (def state-default
-  {:skills #{}
+  {:offset 0
+   :limit 10
+   :skills #{}
    :category constants/category-default
    :feedback-min-rating 1
    :feedback-max-rating 5
@@ -43,6 +45,8 @@
 
 ;; TODO: switch based on dev environment
 (re/reg-event-fx :page.employers/initialize-page initialize-page)
+(re/reg-event-fx :page.employers/set-offset (create-assoc-handler :offset))
+(re/reg-event-fx :page.employers/set-limit (create-assoc-handler :limit))
 (re/reg-event-fx :page.employers/set-skills (create-assoc-handler :skills))
 (re/reg-event-fx :page.employers/add-skill add-skill)
 (re/reg-event-fx :page.employers/set-category (create-assoc-handler :category))

--- a/src/ethlance/ui/page/employers/subscriptions.cljs
+++ b/src/ethlance/ui/page/employers/subscriptions.cljs
@@ -12,7 +12,8 @@
 ;;
 ;; Registered Subscriptions
 ;;
-
+(re/reg-sub :page.employers/offset (create-get-handler :offset))
+(re/reg-sub :page.employers/limit (create-get-handler :limit))
 (re/reg-sub :page.employers/skills (create-get-handler :skills))
 (re/reg-sub :page.employers/category (create-get-handler :category))
 (re/reg-sub :page.employers/feedback-max-rating (create-get-handler :feedback-max-rating))

--- a/src/ethlance/ui/page/invoices.cljs
+++ b/src/ethlance/ui/page/invoices.cljs
@@ -2,7 +2,11 @@
   (:require
    [taoensso.timbre :as log]
    [district.ui.component.page :refer [page]]
+   [district.parsers :refer [parse-int]]
    [reagent.core :as r]
+   [re-frame.core :as re]
+   [district.ui.graphql.subs :as gql]
+   [district.ui.router.subs :as router.subs]
 
    ;; Ethlance Components
    [ethlance.ui.component.button :refer [c-button c-button-icon-label c-button-label]]
@@ -25,9 +29,20 @@
 
 
 (defmethod page :route.invoice/index []
-  (let []
+  (let [*active-page-params (re/subscribe [::router.subs/active-page-params])]
     (fn []
-      (let []
+      (let [invoice-id (-> @*active-page-params :id parse-int)
+            invoice-query
+            @(re/subscribe
+              [::gql/query
+               {:queries
+                [[:invoice
+                  {:invoice/id invoice-id}
+                  [:invoice/id]]]}])
+            {invoice           :invoice
+             preprocessing?    :graphql/preprocessing?
+             loading?          :graphql/loading?
+             errors            :graphql/errors} invoice-query]
         [c-main-layout {:container-opts {:class :invoice-detail-main-container}}
          [:div.title "Invoice"]
          [:a.sub-title

--- a/src/ethlance/ui/page/job_contract.cljs
+++ b/src/ethlance/ui/page/job_contract.cljs
@@ -1,25 +1,20 @@
 (ns ethlance.ui.page.job-contract
   "For viewing individual job contracts"
   (:require
-   [re-frame.core :as re]
-   [taoensso.timbre :as log]
    [district.parsers :refer [parse-int]]
    [district.ui.component.page :refer [page]]
    [district.ui.graphql.subs :as gql]
    [district.ui.router.subs :as router.subs]
    [ethlance.shared.enumeration.currency-type :as enum.currency]
+   [re-frame.core :as re]
+   [taoensso.timbre :as log]
 
    ;; Ethlance Components
    [ethlance.ui.component.button :refer [c-button c-button-label]]
    [ethlance.ui.component.chat :refer [c-chat-log]]
    [ethlance.ui.component.currency-input :refer [c-currency-input]]
-   [ethlance.ui.component.inline-svg :refer [c-inline-svg]]
    [ethlance.ui.component.main-layout :refer [c-main-layout]]
-   [ethlance.ui.component.mobile-search-filter :refer [c-mobile-search-filter]]
-   [ethlance.ui.component.radio-select :refer [c-radio-select c-radio-search-filter-element]]
    [ethlance.ui.component.rating :refer [c-rating]]
-   [ethlance.ui.component.search-input :refer [c-chip-search-input]]
-   [ethlance.ui.component.select-input :refer [c-select-input]]
    [ethlance.ui.component.tabular-layout :refer [c-tabular-layout]]
    [ethlance.ui.component.tag :refer [c-tag c-tag-label]]
    [ethlance.ui.component.textarea-input :refer [c-textarea-input]]))

--- a/src/ethlance/ui/page/job_detail.cljs
+++ b/src/ethlance/ui/page/job_detail.cljs
@@ -1,23 +1,23 @@
 (ns ethlance.ui.page.job-detail
   (:require
-   [taoensso.timbre :as log]
+   [district.parsers :refer [parse-int]]
    [district.ui.component.page :refer [page]]
+   [district.ui.graphql.subs :as gql]
+   [district.ui.router.subs :as router.subs]
+   [re-frame.core :as re]
+   [reagent.core :as r]
+   [taoensso.timbre :as log]
 
    ;; Ethlance Components
    [ethlance.ui.component.button :refer [c-button c-button-icon-label c-button-label]]
    [ethlance.ui.component.carousel :refer [c-carousel c-feedback-slide]]
    [ethlance.ui.component.circle-button :refer [c-circle-icon-button]]
-   [ethlance.ui.component.currency-input :refer [c-currency-input]]
-   [ethlance.ui.component.inline-svg :refer [c-inline-svg]]
    [ethlance.ui.component.main-layout :refer [c-main-layout]]
    [ethlance.ui.component.profile-image :refer [c-profile-image]]
-   [ethlance.ui.component.radio-select :refer [c-radio-select c-radio-search-filter-element]]
    [ethlance.ui.component.rating :refer [c-rating]]
    [ethlance.ui.component.scrollable :refer [c-scrollable]]
-   [ethlance.ui.component.search-input :refer [c-chip-search-input]]
    [ethlance.ui.component.select-input :refer [c-select-input]]
    [ethlance.ui.component.table :refer [c-table]]
-   [ethlance.ui.component.tabular-layout :refer [c-tabular-layout]]
    [ethlance.ui.component.tag :refer [c-tag c-tag-label]]
    [ethlance.ui.component.text-input :refer [c-text-input]]
    [ethlance.ui.component.textarea-input :refer [c-textarea-input]]))
@@ -33,98 +33,110 @@ Please contact us if this sounds interesting.")
 
 
 (defmethod page :route.job/detail []
-  (let []
+  (let [*active-page-params (re/subscribe [::router.subs/active-page-params])]
     (fn []
-      [c-main-layout {:container-opts {:class :job-detail-main-container}}
-       [:div.header
-        [:div.main
-         [:div.title "Finality Labs Full-Stack dApp Dev"]
-         [:div.sub-title "Web, Mobile, and Software Development"]
-         [:div.description fake-description]
-         [:div.label "Required Skills"]
-         [:div.skill-listing
-          [c-tag {} [c-tag-label "System Administration"]]
-          [c-tag {} [c-tag-label "Game Design"]]
-          [c-tag {} [c-tag-label "Game Development"]]
-          [c-tag {} [c-tag-label "Web Programming"]]]
-         [:div.ticket-listing
-          [:div.ticket
-           [:div.label "Available Funds"]
-           [:div.amount "14,000 SNT"]]]
-         [:div.profiles
-          [:div.employer-detail
-           [:div.header "Employer"]
-           [:div.profile-image [c-profile-image {}]]
-           [:div.name "Brian Curran"]
-           [:div.rating [c-rating {:default-rating 3}]]
-           [:div.location "New York, United States"]
-           [:div.fee ""]]
-          [:div.arbiter-detail
-           [:div.header "Arbiter"]
-           [:div.profile-image [c-profile-image {}]]
-           [:div.name "Brian Curran"]
-           [:div.rating [c-rating {:default-rating 3}]]
-           [:div.location "New York, United States"]
-           [:div.fee "Fee: 0.12 ETH"]]]]
-        [:div.side
-         [:div.label "Posted 7 Days Ago"]
-         [c-tag {} [c-tag-label "Hiring"]]
-         [c-tag {} [c-tag-label "Hourly Rate"]]
-         [c-tag {} [c-tag-label "For Months"]]
-         [c-tag {} [c-tag-label "For Expert ($$$)"]]
-         [c-tag {} [c-tag-label "Full Time"]]
-         [c-tag {} [c-tag-label "Needs 3 Freelancers"]]]]
+      (let [job-id (-> @*active-page-params :id parse-int)
+            job-query
+            @(re/subscribe
+              [::gql/query
+               {:queries
+                [[:job
+                  {:job/id job-id}
+                  [:job/id]]]}])
+            {job            :job
+             preprocessing? :graphql/preprocessing?
+             loading?       :graphql/loading?
+             errors         :graphql/errors} job-query]
+        [c-main-layout {:container-opts {:class :job-detail-main-container}}
+         [:div.header
+          [:div.main
+           [:div.title "Finality Labs Full-Stack dApp Dev"]
+           [:div.sub-title "Web, Mobile, and Software Development"]
+           [:div.description fake-description]
+           [:div.label "Required Skills"]
+           [:div.skill-listing
+            [c-tag {} [c-tag-label "System Administration"]]
+            [c-tag {} [c-tag-label "Game Design"]]
+            [c-tag {} [c-tag-label "Game Development"]]
+            [c-tag {} [c-tag-label "Web Programming"]]]
+           [:div.ticket-listing
+            [:div.ticket
+             [:div.label "Available Funds"]
+             [:div.amount "14,000 SNT"]]]
+           [:div.profiles
+            [:div.employer-detail
+             [:div.header "Employer"]
+             [:div.profile-image [c-profile-image {}]]
+             [:div.name "Brian Curran"]
+             [:div.rating [c-rating {:default-rating 3}]]
+             [:div.location "New York, United States"]
+             [:div.fee ""]]
+            [:div.arbiter-detail
+             [:div.header "Arbiter"]
+             [:div.profile-image [c-profile-image {}]]
+             [:div.name "Brian Curran"]
+             [:div.rating [c-rating {:default-rating 3}]]
+             [:div.location "New York, United States"]
+             [:div.fee "Fee: 0.12 ETH"]]]]
+          [:div.side
+           [:div.label "Posted 7 Days Ago"]
+           [c-tag {} [c-tag-label "Hiring"]]
+           [c-tag {} [c-tag-label "Hourly Rate"]]
+           [c-tag {} [c-tag-label "For Months"]]
+           [c-tag {} [c-tag-label "For Expert ($$$)"]]
+           [c-tag {} [c-tag-label "Full Time"]]
+           [c-tag {} [c-tag-label "Needs 3 Freelancers"]]]]
 
-       [:div.proposal-listing
-        [:div.label "Proposals"]
-        [c-scrollable
-         {:forceVisible true :autoHide false}
-         [c-table
-          {:headers ["Candidate" "Rate" "Created" "Status"]}
-          [[:span "Cyrus Keegan"]
-           [:span "$25"]
-           [:span "5 Days Ago"]
-           [:span "Pending"]]]]
-        [:div.button-listing
-         [c-circle-icon-button {:name :ic-arrow-left2 :size :small}]
-         [c-circle-icon-button {:name :ic-arrow-left :size :small}]
-         [c-circle-icon-button {:name :ic-arrow-right :size :small}]
-         [c-circle-icon-button {:name :ic-arrow-right2 :size :small}]]
-        [:div.proposal-form
-         [:div.label "Send Proposal"]
-         [:div.amount-input
-          [c-text-input
-           {:placeholder "0"}]
-          [c-select-input
-           {:label "Token"
-            :selections #{"ETH" "SNT" "DAI"}
-            :default-selection "ETH"}]]
-         [:div.description-input
-          [c-textarea-input
-           {:placeholder "Proposal Description"}]]
-         [c-button {:size :small} [c-button-label "Send"]]]]
+         [:div.proposal-listing
+          [:div.label "Proposals"]
+          [c-scrollable
+           {:forceVisible true :autoHide false}
+           [c-table
+            {:headers ["Candidate" "Rate" "Created" "Status"]}
+            [[:span "Cyrus Keegan"]
+             [:span "$25"]
+             [:span "5 Days Ago"]
+             [:span "Pending"]]]]
+          [:div.button-listing
+           [c-circle-icon-button {:name :ic-arrow-left2 :size :small}]
+           [c-circle-icon-button {:name :ic-arrow-left :size :small}]
+           [c-circle-icon-button {:name :ic-arrow-right :size :small}]
+           [c-circle-icon-button {:name :ic-arrow-right2 :size :small}]]
+          [:div.proposal-form
+           [:div.label "Send Proposal"]
+           [:div.amount-input
+            [c-text-input
+             {:placeholder "0"}]
+            [c-select-input
+             {:label "Token"
+              :selections #{"ETH" "SNT" "DAI"}
+              :default-selection "ETH"}]]
+           [:div.description-input
+            [c-textarea-input
+             {:placeholder "Proposal Description"}]]
+           [c-button {:size :small} [c-button-label "Send"]]]]
 
-       [:div.invoice-listing
-        [:div.label "Invoices"]
-        [c-scrollable
-         {:forceVisible true :autoHide false}
-         [c-table
-          {:headers ["Candidate" "Amount" "Created" "Status"]}
-          [[:span "Giacomo Guilizzoni"]
-           [:span "120 SNT"]
-           [:span "5 Days Ago"]
-           [:span "Full Payment"]]]]
-        [:div.button-listing
-         [c-circle-icon-button {:name :ic-arrow-left2 :size :small}]
-         [c-circle-icon-button {:name :ic-arrow-left :size :small}]
-         [c-circle-icon-button {:name :ic-arrow-right :size :small}]
-         [c-circle-icon-button {:name :ic-arrow-right2 :size :small}]]]
+         [:div.invoice-listing
+          [:div.label "Invoices"]
+          [c-scrollable
+           {:forceVisible true :autoHide false}
+           [c-table
+            {:headers ["Candidate" "Amount" "Created" "Status"]}
+            [[:span "Giacomo Guilizzoni"]
+             [:span "120 SNT"]
+             [:span "5 Days Ago"]
+             [:span "Full Payment"]]]]
+          [:div.button-listing
+           [c-circle-icon-button {:name :ic-arrow-left2 :size :small}]
+           [c-circle-icon-button {:name :ic-arrow-left :size :small}]
+           [c-circle-icon-button {:name :ic-arrow-right :size :small}]
+           [c-circle-icon-button {:name :ic-arrow-right2 :size :small}]]]
 
-       [:div.feedback-listing
-        [:div.label "Feedback"]
-        [c-carousel {}
-         [c-feedback-slide {:rating 1}]
-         [c-feedback-slide {:rating 2}]
-         [c-feedback-slide {:rating 3}]
-         [c-feedback-slide {:rating 4}]
-         [c-feedback-slide {:rating 5}]]]])))
+         [:div.feedback-listing
+          [:div.label "Feedback"]
+          [c-carousel {}
+           [c-feedback-slide {:rating 1}]
+           [c-feedback-slide {:rating 2}]
+           [c-feedback-slide {:rating 3}]
+           [c-feedback-slide {:rating 4}]
+           [c-feedback-slide {:rating 5}]]]]))))

--- a/src/ethlance/ui/page/jobs.cljs
+++ b/src/ethlance/ui/page/jobs.cljs
@@ -6,6 +6,7 @@
    [re-frame.core :as re]
    [taoensso.timbre :as log]
    [district.ui.component.page :refer [page]]
+   [district.ui.graphql.subs :as gql]
 
    [ethlance.shared.enumeration.currency-type :as enum.currency]
    [ethlance.shared.constants :as constants]
@@ -188,7 +189,7 @@
       (let [job-listing @*job-listing
             job-listing-state @*job-listing-state
             loading? (contains? #{:start :loading} job-listing-state)]
-                         
+        
         [:<>
          (cond
            ;; Is the job listing loading?

--- a/src/ethlance/ui/page/new_invoice.cljs
+++ b/src/ethlance/ui/page/new_invoice.cljs
@@ -1,9 +1,12 @@
 (ns ethlance.ui.page.new-invoice
   (:require
-   [taoensso.timbre :as log]
+   [district.parsers :refer [parse-int]]
    [district.ui.component.page :refer [page]]
-   [reagent.core :as r]
+   [district.ui.graphql.subs :as gql]
+   [district.ui.router.subs :as router.subs]
    [re-frame.core :as re]
+   [reagent.core :as r]
+   [taoensso.timbre :as log]
 
    ;; Ethlance Components
    [ethlance.ui.component.button :refer [c-button c-button-icon-label c-button-label]]

--- a/src/ethlance/ui/page/new_job.cljs
+++ b/src/ethlance/ui/page/new_job.cljs
@@ -1,9 +1,12 @@
 (ns ethlance.ui.page.new-job
   (:require
-   [taoensso.timbre :as log]
+   [district.parsers :refer [parse-int]]
    [district.ui.component.page :refer [page]]
-   [reagent.core :as r]
+   [district.ui.graphql.subs :as gql]
+   [district.ui.router.subs :as router.subs]
    [re-frame.core :as re]
+   [reagent.core :as r]
+   [taoensso.timbre :as log]
 
    [ethlance.shared.constants :as constants]
 


### PR DESCRIPTION
Finished adding rest of graphql queries. Additional work will be broken up into more issues.

- Added two new profiles to project.clj 'dev-ui' and 'dev-server', which splits up the figwheel configuration. This resolves issues with starting leiningen instances for individual figwheel instances by separating ports for each.

- A few minor changes to GraphQL schema

- Initial implementations of GraphQL queries within the employer, contract detail, job story, arbiter, candidate pages
