### PR TITLE
Graphql vbump fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 .PHONY: fig-dev-all fig-dev-server fig-dev-ui
 .PHONY: build-server build-ui build-contracts build-dist build-css build
 .PHONY: watch-tests watch-css
-.PHONY: deploy testnet ipfs docker-db
+.PHONY: deploy testnet ipfs postgres
 .PHONY: run build-docs publish-docs
 .PHONY: publish-docs-ipfs publish-docs-ipns
 .PHONY: deps lein-deps test travis-test
@@ -37,7 +37,7 @@ help:
 	@echo "  deploy                  :: Deploy Smart Contracts using truffle."
 	@echo "  testnet                 :: Start the Testnet server."
 	@echo "  ipfs                    :: Start the IPFS daemon."
-	@echo "  docker-db               :: Start the postgresql database as a docker container 'dev-ethlance-psql'"
+	@echo "  postgres                :: Start the postgresql database as a docker container 'dev-ethlance-psql'"
 	@echo "  --"
 	@echo "  build-docs              :: Generate Requirement, Design, and Spec Documents"
 	@echo "  publish-docs            :: Publish the documentation to IPFS"
@@ -149,7 +149,7 @@ ipfs:
 
 
 ETHLANCE_DB_PORT := 5432
-docker-db:
+postgres:
 	docker run                                                       \
                --name    dev-ethlance-psql                               \
                --volume  dev-ethlance-psql-data:/var/lib/postgresql/data \

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,108 +97,108 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@sentry/apm": {
-      "version": "5.15.5",
-      "resolved": "https://registry.npmjs.org/@sentry/apm/-/apm-5.15.5.tgz",
-      "integrity": "sha512-2PyifsiQdvFEQhbL7tQnCKGLOO1JtZeqso3bc6ARJBvKxM77mtyMo/D0C2Uzt9sXCYiALhQ1rbB1aY8iYyglpg==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@sentry/apm/-/apm-5.19.0.tgz",
+      "integrity": "sha512-CwjXwkj31TlktW3FAM9GqF9zbjAyH58nrguCwx/uPTkpJN1Uj4MGh74oWFo45a4f/cLjjrpLA/mbwBdhs0z8sw==",
       "requires": {
-        "@sentry/browser": "5.15.5",
-        "@sentry/hub": "5.15.5",
-        "@sentry/minimal": "5.15.5",
-        "@sentry/types": "5.15.5",
-        "@sentry/utils": "5.15.5",
+        "@sentry/browser": "5.19.0",
+        "@sentry/hub": "5.19.0",
+        "@sentry/minimal": "5.19.0",
+        "@sentry/types": "5.19.0",
+        "@sentry/utils": "5.19.0",
         "tslib": "^1.9.3"
       },
       "dependencies": {
         "@sentry/hub": {
-          "version": "5.15.5",
-          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.15.5.tgz",
-          "integrity": "sha512-zX9o49PcNIVMA4BZHe//GkbQ4Jx+nVofqU/Il32/IbwKhcpPlhGX3c1sOVQo4uag3cqd/JuQsk+DML9TKkN0Lw==",
+          "version": "5.19.0",
+          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.19.0.tgz",
+          "integrity": "sha512-UFaQLa1XAa02ZcxUmN9GdDpGs3vHK1LpOyYooimX8ttWa4KAkMuP+O5uXH1TJabry6o/cRwYisg2k6PBSy8gxw==",
           "requires": {
-            "@sentry/types": "5.15.5",
-            "@sentry/utils": "5.15.5",
+            "@sentry/types": "5.19.0",
+            "@sentry/utils": "5.19.0",
             "tslib": "^1.9.3"
           }
         },
         "@sentry/minimal": {
-          "version": "5.15.5",
-          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.15.5.tgz",
-          "integrity": "sha512-zQkkJ1l9AjmU/Us5IrOTzu7bic4sTPKCatptXvLSTfyKW7N6K9MPIIFeSpZf9o1yM2sRYdK7GV08wS2eCT3JYw==",
+          "version": "5.19.0",
+          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.19.0.tgz",
+          "integrity": "sha512-3FHgirwOuOMF4VlwHboYObPT9c0S9b9y5FW0DGgNt8sJPezS00VaJti/38ZwOHQJ4fJ6ubt/Y3Kz0eBTVxMCCQ==",
           "requires": {
-            "@sentry/hub": "5.15.5",
-            "@sentry/types": "5.15.5",
+            "@sentry/hub": "5.19.0",
+            "@sentry/types": "5.19.0",
             "tslib": "^1.9.3"
           }
         },
         "@sentry/types": {
-          "version": "5.15.5",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.15.5.tgz",
-          "integrity": "sha512-F9A5W7ucgQLJUG4LXw1ZIy4iLevrYZzbeZ7GJ09aMlmXH9PqGThm1t5LSZlVpZvUfQ2rYA8NU6BdKJSt7B5LPw=="
+          "version": "5.19.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.19.0.tgz",
+          "integrity": "sha512-NlHLS9mwCEimKUA5vClAwVhXFLsqSF3VJEXU+K61fF6NZx8zfJi/HTrIBtoM4iNSAt9o4XLQatC1liIpBC06tg=="
         },
         "@sentry/utils": {
-          "version": "5.15.5",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.15.5.tgz",
-          "integrity": "sha512-Nl9gl/MGnzSkuKeo3QaefoD/OJrFLB8HmwQ7HUbTXb6E7yyEzNKAQMHXGkwNAjbdYyYbd42iABP6Y5F/h39NtA==",
+          "version": "5.19.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.19.0.tgz",
+          "integrity": "sha512-EU/T9aJrI8isexRnyDx5InNw/HjSQ0nKI7YWdiwfFrJusqQ/uisnCGK7vw6gGHDgiAHMXW3TJ38NHpNBin6y7Q==",
           "requires": {
-            "@sentry/types": "5.15.5",
+            "@sentry/types": "5.19.0",
             "tslib": "^1.9.3"
           }
         }
       }
     },
     "@sentry/browser": {
-      "version": "5.15.5",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.15.5.tgz",
-      "integrity": "sha512-rqDvjk/EvogfdbZ4TiEpxM/lwpPKmq23z9YKEO4q81+1SwJNua53H60dOk9HpRU8nOJ1g84TMKT2Ov8H7sqDWA==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.19.0.tgz",
+      "integrity": "sha512-Cz8PnzC5NGfpHIGCmHLgA6iDEBVELwo4Il/iFweXjs4+VL4biw62lI32Q4iLCCpmX0t5UvrWBOnju2v8zuFIjA==",
       "requires": {
-        "@sentry/core": "5.15.5",
-        "@sentry/types": "5.15.5",
-        "@sentry/utils": "5.15.5",
+        "@sentry/core": "5.19.0",
+        "@sentry/types": "5.19.0",
+        "@sentry/utils": "5.19.0",
         "tslib": "^1.9.3"
       },
       "dependencies": {
         "@sentry/core": {
-          "version": "5.15.5",
-          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.15.5.tgz",
-          "integrity": "sha512-enxBLv5eibBMqcWyr+vApqeix8uqkfn0iGsD3piKvoMXCgKsrfMwlb/qo9Ox0lKr71qIlZVt+9/A2vZohdgnlg==",
+          "version": "5.19.0",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.19.0.tgz",
+          "integrity": "sha512-ry1Zms6jrVQPEwmfywItyUhOgabPrykd8stR1x/u2t1YiISWlR813fE5nzdwgW5mxEitXz/ikTwvrfK3egsDWQ==",
           "requires": {
-            "@sentry/hub": "5.15.5",
-            "@sentry/minimal": "5.15.5",
-            "@sentry/types": "5.15.5",
-            "@sentry/utils": "5.15.5",
+            "@sentry/hub": "5.19.0",
+            "@sentry/minimal": "5.19.0",
+            "@sentry/types": "5.19.0",
+            "@sentry/utils": "5.19.0",
             "tslib": "^1.9.3"
           }
         },
         "@sentry/hub": {
-          "version": "5.15.5",
-          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.15.5.tgz",
-          "integrity": "sha512-zX9o49PcNIVMA4BZHe//GkbQ4Jx+nVofqU/Il32/IbwKhcpPlhGX3c1sOVQo4uag3cqd/JuQsk+DML9TKkN0Lw==",
+          "version": "5.19.0",
+          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.19.0.tgz",
+          "integrity": "sha512-UFaQLa1XAa02ZcxUmN9GdDpGs3vHK1LpOyYooimX8ttWa4KAkMuP+O5uXH1TJabry6o/cRwYisg2k6PBSy8gxw==",
           "requires": {
-            "@sentry/types": "5.15.5",
-            "@sentry/utils": "5.15.5",
+            "@sentry/types": "5.19.0",
+            "@sentry/utils": "5.19.0",
             "tslib": "^1.9.3"
           }
         },
         "@sentry/minimal": {
-          "version": "5.15.5",
-          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.15.5.tgz",
-          "integrity": "sha512-zQkkJ1l9AjmU/Us5IrOTzu7bic4sTPKCatptXvLSTfyKW7N6K9MPIIFeSpZf9o1yM2sRYdK7GV08wS2eCT3JYw==",
+          "version": "5.19.0",
+          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.19.0.tgz",
+          "integrity": "sha512-3FHgirwOuOMF4VlwHboYObPT9c0S9b9y5FW0DGgNt8sJPezS00VaJti/38ZwOHQJ4fJ6ubt/Y3Kz0eBTVxMCCQ==",
           "requires": {
-            "@sentry/hub": "5.15.5",
-            "@sentry/types": "5.15.5",
+            "@sentry/hub": "5.19.0",
+            "@sentry/types": "5.19.0",
             "tslib": "^1.9.3"
           }
         },
         "@sentry/types": {
-          "version": "5.15.5",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.15.5.tgz",
-          "integrity": "sha512-F9A5W7ucgQLJUG4LXw1ZIy4iLevrYZzbeZ7GJ09aMlmXH9PqGThm1t5LSZlVpZvUfQ2rYA8NU6BdKJSt7B5LPw=="
+          "version": "5.19.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.19.0.tgz",
+          "integrity": "sha512-NlHLS9mwCEimKUA5vClAwVhXFLsqSF3VJEXU+K61fF6NZx8zfJi/HTrIBtoM4iNSAt9o4XLQatC1liIpBC06tg=="
         },
         "@sentry/utils": {
-          "version": "5.15.5",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.15.5.tgz",
-          "integrity": "sha512-Nl9gl/MGnzSkuKeo3QaefoD/OJrFLB8HmwQ7HUbTXb6E7yyEzNKAQMHXGkwNAjbdYyYbd42iABP6Y5F/h39NtA==",
+          "version": "5.19.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.19.0.tgz",
+          "integrity": "sha512-EU/T9aJrI8isexRnyDx5InNw/HjSQ0nKI7YWdiwfFrJusqQ/uisnCGK7vw6gGHDgiAHMXW3TJ38NHpNBin6y7Q==",
           "requires": {
-            "@sentry/types": "5.15.5",
+            "@sentry/types": "5.19.0",
             "tslib": "^1.9.3"
           }
         }
@@ -234,15 +234,15 @@
       }
     },
     "@sentry/node": {
-      "version": "5.15.5",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.15.5.tgz",
-      "integrity": "sha512-BK0iTOiiIM0UnydLeT/uUBY1o1Sp85aqwaQRMfZbjMCsgXERLNGvzzV68FDH1cyC1nR6dREK3Gs8bxS4S54aLQ==",
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.19.0.tgz",
+      "integrity": "sha512-dqpH9ff+ropVpv0vJnNEOm601Gq/VFvdiN4Ge6JaKEVz+utx6JafEXjXsQqngxXp3xvJw6g0s6cw4HJ+Mx7dow==",
       "requires": {
-        "@sentry/apm": "5.15.5",
-        "@sentry/core": "5.15.5",
-        "@sentry/hub": "5.15.5",
-        "@sentry/types": "5.15.5",
-        "@sentry/utils": "5.15.5",
+        "@sentry/apm": "5.19.0",
+        "@sentry/core": "5.19.0",
+        "@sentry/hub": "5.19.0",
+        "@sentry/types": "5.19.0",
+        "@sentry/utils": "5.19.0",
         "cookie": "^0.3.1",
         "https-proxy-agent": "^4.0.0",
         "lru_map": "^0.3.3",
@@ -250,48 +250,48 @@
       },
       "dependencies": {
         "@sentry/core": {
-          "version": "5.15.5",
-          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.15.5.tgz",
-          "integrity": "sha512-enxBLv5eibBMqcWyr+vApqeix8uqkfn0iGsD3piKvoMXCgKsrfMwlb/qo9Ox0lKr71qIlZVt+9/A2vZohdgnlg==",
+          "version": "5.19.0",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.19.0.tgz",
+          "integrity": "sha512-ry1Zms6jrVQPEwmfywItyUhOgabPrykd8stR1x/u2t1YiISWlR813fE5nzdwgW5mxEitXz/ikTwvrfK3egsDWQ==",
           "requires": {
-            "@sentry/hub": "5.15.5",
-            "@sentry/minimal": "5.15.5",
-            "@sentry/types": "5.15.5",
-            "@sentry/utils": "5.15.5",
+            "@sentry/hub": "5.19.0",
+            "@sentry/minimal": "5.19.0",
+            "@sentry/types": "5.19.0",
+            "@sentry/utils": "5.19.0",
             "tslib": "^1.9.3"
           }
         },
         "@sentry/hub": {
-          "version": "5.15.5",
-          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.15.5.tgz",
-          "integrity": "sha512-zX9o49PcNIVMA4BZHe//GkbQ4Jx+nVofqU/Il32/IbwKhcpPlhGX3c1sOVQo4uag3cqd/JuQsk+DML9TKkN0Lw==",
+          "version": "5.19.0",
+          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.19.0.tgz",
+          "integrity": "sha512-UFaQLa1XAa02ZcxUmN9GdDpGs3vHK1LpOyYooimX8ttWa4KAkMuP+O5uXH1TJabry6o/cRwYisg2k6PBSy8gxw==",
           "requires": {
-            "@sentry/types": "5.15.5",
-            "@sentry/utils": "5.15.5",
+            "@sentry/types": "5.19.0",
+            "@sentry/utils": "5.19.0",
             "tslib": "^1.9.3"
           }
         },
         "@sentry/minimal": {
-          "version": "5.15.5",
-          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.15.5.tgz",
-          "integrity": "sha512-zQkkJ1l9AjmU/Us5IrOTzu7bic4sTPKCatptXvLSTfyKW7N6K9MPIIFeSpZf9o1yM2sRYdK7GV08wS2eCT3JYw==",
+          "version": "5.19.0",
+          "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.19.0.tgz",
+          "integrity": "sha512-3FHgirwOuOMF4VlwHboYObPT9c0S9b9y5FW0DGgNt8sJPezS00VaJti/38ZwOHQJ4fJ6ubt/Y3Kz0eBTVxMCCQ==",
           "requires": {
-            "@sentry/hub": "5.15.5",
-            "@sentry/types": "5.15.5",
+            "@sentry/hub": "5.19.0",
+            "@sentry/types": "5.19.0",
             "tslib": "^1.9.3"
           }
         },
         "@sentry/types": {
-          "version": "5.15.5",
-          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.15.5.tgz",
-          "integrity": "sha512-F9A5W7ucgQLJUG4LXw1ZIy4iLevrYZzbeZ7GJ09aMlmXH9PqGThm1t5LSZlVpZvUfQ2rYA8NU6BdKJSt7B5LPw=="
+          "version": "5.19.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.19.0.tgz",
+          "integrity": "sha512-NlHLS9mwCEimKUA5vClAwVhXFLsqSF3VJEXU+K61fF6NZx8zfJi/HTrIBtoM4iNSAt9o4XLQatC1liIpBC06tg=="
         },
         "@sentry/utils": {
-          "version": "5.15.5",
-          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.15.5.tgz",
-          "integrity": "sha512-Nl9gl/MGnzSkuKeo3QaefoD/OJrFLB8HmwQ7HUbTXb6E7yyEzNKAQMHXGkwNAjbdYyYbd42iABP6Y5F/h39NtA==",
+          "version": "5.19.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.19.0.tgz",
+          "integrity": "sha512-EU/T9aJrI8isexRnyDx5InNw/HjSQ0nKI7YWdiwfFrJusqQ/uisnCGK7vw6gGHDgiAHMXW3TJ38NHpNBin6y7Q==",
           "requires": {
-            "@sentry/types": "5.15.5",
+            "@sentry/types": "5.19.0",
             "tslib": "^1.9.3"
           }
         }

--- a/project.clj
+++ b/project.clj
@@ -78,7 +78,7 @@
                  [district0x/district-ui-component-input "1.0.0"]
                  [district0x/district-ui-component-notification "1.0.0"]
                  [district0x/district-ui-component-tx-button "1.0.0"]
-                 [district0x/district-ui-graphql "1.0.12"]
+                 [district0x/district-ui-graphql "1.0.13"]
                  [district0x/district-ui-logging "1.1.0"]
                  [district0x/district-ui-notification "1.0.1"]
                  [district0x/district-ui-now "1.0.2"]


### PR DESCRIPTION
- Fixes issues with district.ui.graphql not working with later versions of clojurescript.
- Updated `make postgres`
  - updated version won't leave a hanging container when you exit, and will mount a local volume.