### PR TITLE
Use Ethereum addresses as primary key for Job, User

### DIFF
--- a/server/src/district/server/async_db.cljs
+++ b/server/src/district/server/async_db.cljs
@@ -71,7 +71,6 @@
   ([conn-or-chan query-str values]
    (safe-go
      (let [conn (if (= js/Promise (type conn-or-chan)) (<! conn-or-chan) conn-or-chan)
-           _ (println ">> conn is" conn)
            res (<! (.query conn query-str (clj->js (or values []))))]
        (->> (js->clj (.-rows res))
             (map #(map-keys transform-result-keys-fn %)))))))
@@ -131,16 +130,16 @@
     (safe-go
      (let [conn (<? (get-connection))
            res (<? (run! conn {:create-table [:usr :if-not-exists]
-                               :with-columns [[[:user/address :varchar]
+                               :with-columns [[[:user/id :varchar]
                                                [:user/type :varchar]
 
                                                ;; PK
-                                               [(sql/call :primary-key :user/address)]]]}))]))
+                                               [(sql/call :primary-key :user/id)]]]}))]))
 
     (safe-go
      (let [conn (<? (get-connection))]
        (run! conn {:insert-into :usr
-                   :columns [:user/address :user/type]
+                   :columns [:user/id :user/type]
                    :values [["address1" "type1"]]})))
 
     (safe-go

--- a/server/src/ethlance/server/db.cljs
+++ b/server/src/ethlance/server/db.cljs
@@ -44,7 +44,7 @@
   ;;
   [{:table-name :Users
     :table-columns
-    [[:user/address :varchar]
+    [[:user/id column-types/address]
      [:user/email :varchar not-nil]
      [:user/name :varchar not-nil]
      [:user/country :varchar]
@@ -55,66 +55,66 @@
      [:user/linkedin-username :varchar]
      [:user/status :varchar]
      ;; PK
-     [(sql/call :primary-key :user/address)]]
+     [(sql/call :primary-key :user/id)]]
     :list-keys []}
 
    {:table-name :UserSocialAccounts
     :table-columns
-    [[:user/address :varchar]
+    [[:user/id column-types/address]
      [:user/github-username :varchar]
      [:user/linkedin-username :varchar]
      ;; PK
-     [(sql/call :primary-key :user/address)]]
+     [(sql/call :primary-key :user/id)]]
     :list-keys []}
 
    {:table-name :Candidate
     :table-columns
-    [[:user/address :varchar]
+    [[:user/id column-types/address]
      [:candidate/bio :varchar]
      [:candidate/professional-title :varchar]
      [:candidate/rate :integer not-nil]
      [:candidate/rate-currency-id :varchar not-nil]
      [:candidate/rating :real]
      ;; PK
-     [(sql/call :primary-key :user/address)]
+     [(sql/call :primary-key :user/id)]
      ;; FKs
-     [(sql/call :foreign-key :user/address) (sql/call :references :Users :user/address) (sql/raw "ON DELETE CASCADE")]]
+     [(sql/call :foreign-key :user/id) (sql/call :references :Users :user/id) (sql/raw "ON DELETE CASCADE")]]
     :list-keys []}
 
    {:table-name :Employer
     :table-columns
-    [[:user/address :varchar not-nil]
+    [[:user/id column-types/address]
      [:employer/bio :varchar]
      [:employer/professional-title :varchar]
      [:employer/rating :real]
      ;; PK
-     [(sql/call :primary-key :user/address)]
+     [(sql/call :primary-key :user/id)]
      ;; FKs
-     [(sql/call :foreign-key :user/address) (sql/call :references :Users :user/address) (sql/raw "ON DELETE CASCADE")]]
+     [(sql/call :foreign-key :user/id) (sql/call :references :Users :user/id) (sql/raw "ON DELETE CASCADE")]]
     :list-keys []}
 
    {:table-name :Arbiter
     :table-columns
-    [[:user/address :varchar not-nil]
+    [[:user/id column-types/address]
      [:arbiter/bio :varchar]
      [:arbiter/professional-title :varchar]
      [:arbiter/fee :integer not-nil]
      [:arbiter/fee-currency-id :varchar not-nil]
      [:arbiter/rating :real]
      ;; PK
-     [(sql/call :primary-key :user/address)]
+     [(sql/call :primary-key :user/id)]
      ;; FKs
-     [(sql/call :foreign-key :user/address) (sql/call :references :Users :user/address) (sql/raw "ON DELETE CASCADE")]]
+     [(sql/call :foreign-key :user/id) (sql/call :references :Users :user/id) (sql/raw "ON DELETE CASCADE")]]
     :list-keys []}
 
    {:table-name :UserLanguage
     :table-columns
-    [[:user/address :varchar not-nil]
+    [[:user/id column-types/address]
      [:language/id :varchar not-nil]
      ;; PK
-     [(sql/call :primary-key :user/address :language/id)]
+     [(sql/call :primary-key :user/id :language/id)]
      ;; FKs
-     [(sql/call :foreign-key :user/address) (sql/call :references :Users :user/address) (sql/raw "ON DELETE CASCADE")]]
+     [(sql/call :foreign-key :user/id) (sql/call :references :Users :user/id) (sql/raw "ON DELETE CASCADE")]]
     :list-keys []}
 
    {:table-name :Category
@@ -143,54 +143,53 @@
     :list-keys []}
    {:table-name :ArbiterCategory
     :table-columns
-    [[:user/address :varchar not-nil]
+    [[:user/id column-types/address]
      [:category/id :varchar not-nil]
      ;; PK
-     [(sql/call :primary-key :user/address :category/id)]
+     [(sql/call :primary-key :user/id :category/id)]
      ;; FKs
-     [(sql/call :foreign-key :user/address) (sql/call :references :Users :user/address) (sql/raw "ON DELETE CASCADE")]
+     [(sql/call :foreign-key :user/id) (sql/call :references :Users :user/id) (sql/raw "ON DELETE CASCADE")]
      [(sql/call :foreign-key :category/id) (sql/call :references :Category :category/id) (sql/raw "ON DELETE CASCADE")]]
     :list-keys []}
 
    {:table-name :ArbiterSkill
     :table-columns
-    [[:user/address :varchar not-nil]
+    [[:user/id :varchar not-nil]
      [:skill/id :varchar not-nil]
      ;; PK
-     [(sql/call :primary-key :user/address :skill/id)]
+     [(sql/call :primary-key :user/id :skill/id)]
      ;; FKs
-     [(sql/call :foreign-key :user/address) (sql/call :references :Users :user/address) (sql/raw "ON DELETE CASCADE")]
+     [(sql/call :foreign-key :user/id) (sql/call :references :Users :user/id) (sql/raw "ON DELETE CASCADE")]
      [(sql/call :foreign-key :skill/id) (sql/call :references :Skill :skill/id) (sql/raw "ON DELETE CASCADE")]]
     :list-keys []}
 
    {:table-name :CandidateCategory
     :table-columns
-    [[:user/address :varchar not-nil]
+    [[:user/id :varchar not-nil]
      [:category/id :varchar not-nil]
      ;; PK
-     [(sql/call :primary-key :user/address :category/id)]
+     [(sql/call :primary-key :user/id :category/id)]
      ;; FKs
-     [(sql/call :foreign-key :user/address) (sql/call :references :Users :user/address) (sql/raw "ON DELETE CASCADE")]
+     [(sql/call :foreign-key :user/id) (sql/call :references :Users :user/id) (sql/raw "ON DELETE CASCADE")]
      [(sql/call :foreign-key :category/id) (sql/call :references :Category :category/id) (sql/raw "ON DELETE CASCADE")]]
     :list-keys []}
 
    {:table-name :CandidateSkill
     :table-columns
-    [[:user/address :varchar not-nil]
+    [[:user/id :varchar not-nil]
      [:skill/id :varchar not-nil]
      ;; PK
-     [(sql/call :primary-key :user/address :skill/id)]
+     [(sql/call :primary-key :user/id :skill/id)]
      ;; FKs
-     [(sql/call :foreign-key :user/address) (sql/call :references :Users :user/address) (sql/raw "ON DELETE CASCADE")]
+     [(sql/call :foreign-key :user/id) (sql/call :references :Users :user/id) (sql/raw "ON DELETE CASCADE")]
      [(sql/call :foreign-key :skill/id) (sql/call :references :Skill :skill/id) (sql/raw "ON DELETE CASCADE")]]
     :list-keys []}
 
    {:table-name :Job
     :table-columns
-    [[:job/id :serial]
-     [:job/contract column-types/address] ; add unique & not null constraints
-                                          ; https://github.com/seancorfield/honeysql/blob/develop/doc/clause-reference.md
-                                          ; https://github.com/district0x/d0x-libs/blob/master/server/district-server-db/src/district/server/db/column_types.cljs
+    [[:job/id column-types/address] ; add unique & not null constraints
+                                    ; https://github.com/seancorfield/honeysql/blob/develop/doc/clause-reference.md
+                                    ; https://github.com/district0x/d0x-libs/blob/master/server/district-server-db/src/district/server/db/column_types.cljs
      [:job/creator column-types/address]
      [:job/title :varchar not-nil]
      [:job/description :varchar not-nil]
@@ -222,24 +221,24 @@
 
    {:table-name :JobCreator
     :table-columns
-    [[:job/id :integer]
-     [:user/address :varchar]
+    [[:job/id column-types/address]
+     [:user/id :varchar]
      ;; PK
-     [(sql/call :primary-key :job/id :user/address)]
+     [(sql/call :primary-key :job/id :user/id)]
      ;; FKs
-     [(sql/call :foreign-key :user/address) (sql/call :references :Users :user/address) (sql/raw "ON DELETE CASCADE")]
+     [(sql/call :foreign-key :user/id) (sql/call :references :Users :user/id) (sql/raw "ON DELETE CASCADE")]
      [(sql/call :foreign-key :job/id) (sql/call :references :Job :job/id) (sql/raw "ON DELETE CASCADE")]]
     :list-keys []}
 
    {:table-name :JobContribution
     :table-columns
-    [[:job/id :integer]
-     [:user/address :varchar]
+    [[:job/id column-types/address]
+     [:user/id :varchar]
      [:job-contribution/amount :bigint]
      [:job-contribution/id :integer]
 
      ;; PK
-     [(sql/call :primary-key :job/id :user/address)]
+     [(sql/call :primary-key :job/id :user/id)]
 
      ;; FKs
      [(sql/call :foreign-key :job/id) (sql/call :references :Job :job/id) (sql/raw "ON DELETE CASCADE")]
@@ -247,7 +246,7 @@
 
    {:table-name :JobSkill
     :table-columns
-    [[:job/id :integer]
+    [[:job/id column-types/address]
      [:skill/id :varchar]
      ;; PK
      [(sql/call :primary-key :job/id :skill/id)]
@@ -257,23 +256,23 @@
 
    {:table-name :JobArbiter
     :table-columns
-    [[:job/id :integer]
-     [:user/address :varchar]
+    [[:job/id column-types/address]
+     [:user/id :varchar]
      [:job-arbiter/fee :integer]
      [:job-arbiter/fee-currency-id :varchar]
      [:job-arbiter/status :varchar]
      [:job-arbiter/date-accepted :bigint]
      ;; PK
-     [(sql/call :primary-key :job/id :user/address)]
+     [(sql/call :primary-key :job/id :user/id)]
 
      ;; FKs
-     [(sql/call :foreign-key :user/address) (sql/call :references :Users :user/address) (sql/raw "ON DELETE CASCADE")]
+     [(sql/call :foreign-key :user/id) (sql/call :references :Users :user/id) (sql/raw "ON DELETE CASCADE")]
      [(sql/call :foreign-key :job/id) (sql/call :references :Job :job/id) (sql/raw "ON DELETE CASCADE")]]
     :list-keys []}
 
    {:table-name :JobFile
     :table-columns
-    [[:job/id :integer]
+    [[:job/id column-types/address]
      [:job/file-id :integer]
 
      ;; FKs
@@ -298,8 +297,7 @@
    {:table-name :JobStory
     :table-columns
     [[:job-story/id :serial]
-     [:job/contract :text]
-     [:job/id :integer]
+     [:job/id column-types/address]
      [:job-story/status :varchar]
      [:job-story/date-created :bigint]
      [:job-story/date-updated :bigint]
@@ -359,13 +357,13 @@
     [[:job-story/id :integer not-nil]
      [:message/id :integer not-nil]
      [:feedback/rating :integer not-nil]
-     [:user/address :varchar not-nil]
+     [:user/id :varchar not-nil]
 
      ;; PK
      [(sql/call :primary-key :job-story/id :message/id)]
      ;; FKs
      [(sql/call :foreign-key :job-story/id) (sql/call :references :JobStory :job-story/id) (sql/raw "ON DELETE CASCADE")]
-     [(sql/call :foreign-key :user/address) (sql/call :references :Users :user/address) (sql/raw "ON DELETE CASCADE")]
+     [(sql/call :foreign-key :user/id) (sql/call :references :Users :user/id) (sql/raw "ON DELETE CASCADE")]
      [(sql/call :foreign-key :message/id) (sql/call :references :Message :message/id) (sql/raw "ON DELETE CASCADE")]]
     :list-keys []}
 
@@ -625,7 +623,7 @@
   "Returns map suitablefor honeysql with upsert semantics to store associated model.
   Association is identified by address (foreign key)"
   [address table column values]
-  (let [fk-column :user/address
+  (let [fk-column :user/id
         value-tuples (map #(into [address %]) values)]
     {:insert-into table
      :columns [fk-column column]
@@ -636,7 +634,7 @@
 (defn- remove-old-associations
   "Deletes rows identified by address"
   [address table]
-  (let [fk-column :user/address]
+  (let [fk-column :user/id]
     {:delete-from table :where [:= fk-column address]}))
 
 (defn- add-missing-values
@@ -653,25 +651,25 @@
                         {:insert-into :Users,
                          :values [values]
                          :upsert
-                         (array-map :on-conflict [:user/address]
+                         (array-map :on-conflict [:user/id]
                                     :do-update-set (keys values))}))]
      (case type
        :arbiter (let [arbiter (select-keys user (get-table-column-names :Arbiter))]
                   (<? (db/run! conn {:insert-into :Arbiter
                                      :values [arbiter]
-                                     :upsert (array-map :on-conflict [:user/address]
+                                     :upsert (array-map :on-conflict [:user/id]
                                                         :do-update-set (keys arbiter))})))
        :employer (let [employer (select-keys user (get-table-column-names :Employer))]
                    (<? (db/run! conn {:insert-into :Employer
                                       :values [employer]
-                                      :upsert (array-map :on-conflict [:user/address]
+                                      :upsert (array-map :on-conflict [:user/id]
                                                          :do-update-set (keys employer))})))
        :candidate (let [candidate (select-keys user (get-table-column-names :Candidate))]
                     (<? (db/run! conn {:insert-into :Candidate
                                        :values [candidate]
-                                       :upsert (array-map :on-conflict [:user/address]
+                                       :upsert (array-map :on-conflict [:user/id]
                                                           :do-update-set (keys candidate))}))
-                    (doseq [address [(:user/address user)]
+                    (doseq [address [(:user/id user)]
                             target [[:Category :CandidateCategory :category/id (:candidate/categories user)]
                                     [:Skill :CandidateSkill :skill/id (:candidate/skills user)]
                                     [nil :UserLanguage :language/id (:user/languages user)]]]
@@ -687,7 +685,7 @@
                    {:insert-into :UserSocialAccounts,
                     :values [values]
                     :upsert
-                    (array-map :on-conflict [:user/address]
+                    (array-map :on-conflict [:user/id]
                                :do-update-set (keys values))})))))
 
 (defn add-skills [conn job-id skills]
@@ -696,7 +694,6 @@
       (<? (insert-row! conn :JobSkill {:job/id job-id :skill/id skill})))))
 
 (defn add-job [conn job]
-  (println ">>> ethlance.server.db/add-job" job)
   (safe-go
     (let [skills (:job/required-skills job)
           job-fields (dissoc job :job/required-skills)
@@ -724,7 +721,7 @@
                     :message/id)
          job-story-id (or (:job-story/id message)
                           (:job-story/id (<? (insert-row! conn :JobStory
-                                                          {:job-story/contract (:job/contract message)
+                                                          {:job/id (:job/id message)
                                                            :job-story/candidate (:message/creator message)
                                                            :job-story/date-created (:message/date-created message)
                                                            :job-story/status "proposed"
@@ -796,12 +793,12 @@
 (defn add-job-arbiter [conn job-id user-address]
   (safe-go
    (<? (insert-row! conn :JobArbiter {:job/id job-id
-                                      :user/address user-address}))))
+                                      :user/id user-address}))))
 
 (defn add-contribution [conn job-id contributor-address contribution-id amount]
   (safe-go
    (<? (insert-row! conn :JobContribution {:job/id job-id
-                                           :user/address contributor-address
+                                           :user/id contributor-address
                                            :job-contribution/amount amount
                                            :job-contribution/id contribution-id}))))
 

--- a/server/src/ethlance/server/graphql/authorization.cljs
+++ b/server/src/ethlance/server/graphql/authorization.cljs
@@ -22,7 +22,7 @@
      (log/info "No access-token header present in request")
 
      access-token
-     (let [user {:user/address (aget (parse-jwt access-token sign-in-secret) "userAddress")}]
+     (let [user {:user/id (aget (parse-jwt access-token sign-in-secret) "userAddress")}]
        user)
 
      :else (log/info "Invalid access-token header"))))

--- a/server/src/ethlance/server/syncer.cljs
+++ b/server/src/ethlance/server/syncer.cljs
@@ -68,7 +68,6 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn build-ethlance-job-data-from-ipfs-object [ethlance-job-data]
-  (println ">>> build-ethlance-job-data-from-ipfs-object" ethlance-job-data)
   {:job/title (:job/title ethlance-job-data)
    :job/description (:job/description ethlance-job-data)
    :job/category (:job/category ethlance-job-data)
@@ -207,8 +206,8 @@
          offered-value (offered-vec->flat-map (first (:offered-values args)))
          token-address (:token-address offered-value)]
      (<? (ethlance-db/add-job conn
-                              (merge {:job/status  "active" ;; draft -> active -> finished hiring -> closed
-                                      :job/contract (:job args)
+                              (merge {:job/id (:job args)
+                                      :job/status  "active" ;; draft -> active -> finished hiring -> closed
                                       :job/creator (:creator args)
                                       :job/date-created (:timestamp event)
                                       :job/date-updated (:timestamp event)

--- a/server/src/ethlance/server/utils.cljs
+++ b/server/src/ethlance/server/utils.cljs
@@ -30,7 +30,6 @@
      (ipfs-files/fget (str "/ipfs/" meta-hash)
                       {:req-opts {:compress false}}
                       (fn [err content]
-                        (println ">>> ethlance.server.utils/get-ipfs-meta" {:meta-hash meta-hash :content content})
                         (cond
                           err
                           (let [err-txt "Error when retrieving metadata from ipfs"]

--- a/server/src/tests/graphql/generator.cljs
+++ b/server/src/tests/graphql/generator.cljs
@@ -33,7 +33,7 @@
    (doseq [address user-addresses language languages]
      (let [[speaks? _] (shuffle [true false])]
        (when speaks?
-         (<? (ethlance-db/insert-row! conn :UserLanguage {:user/address address
+         (<? (ethlance-db/insert-row! conn :UserLanguage {:user/id address
                                                           :language/id language})))))))
 
 (defn generate-categories [conn categories [_ candidate arbiter]]
@@ -41,10 +41,10 @@
    (doseq [category categories]
      (<? (ethlance-db/insert-row! conn :Category {:category/id category}))
 
-     (<? (ethlance-db/insert-row! conn :CandidateCategory {:user/address candidate
+     (<? (ethlance-db/insert-row! conn :CandidateCategory {:user/id candidate
                                                            :category/id category}))
 
-     (<? (ethlance-db/insert-row! conn :ArbiterCategory {:user/address arbiter
+     (<? (ethlance-db/insert-row! conn :ArbiterCategory {:user/id arbiter
                                                          :category/id category})))))
 
 (defn generate-skills [conn skills [_ candidate arbiter]]
@@ -52,10 +52,10 @@
    (doseq [skill skills]
      (<? (ethlance-db/insert-row! conn :Skill {:skill/id skill}))
 
-     (<? (ethlance-db/insert-row! conn :CandidateSkill {:user/address candidate
+     (<? (ethlance-db/insert-row! conn :CandidateSkill {:user/id candidate
                                                         :skill/id skill}))
 
-     (<? (ethlance-db/insert-row! conn :ArbiterSkill {:user/address arbiter
+     (<? (ethlance-db/insert-row! conn :ArbiterSkill {:user/id arbiter
                                                       :skill/id skill})))))
 
 (defn generate-users [conn user-addresses]
@@ -71,7 +71,7 @@
            from (rand-int 100)
            bio (subs lorem from (+ 100 from))
            [professional-title _] (shuffle ["Dr" "Md" "PhD" "Mgr" "Master of Wine and Whisky"])]
-       (<? (ethlance-db/insert-row! conn :Users {:user/address address
+       (<? (ethlance-db/insert-row! conn :Users {:user/id address
                                                  :user/type (case address-owner
                                                               "EMPLOYER" :employer
                                                               "CANDIDATE" :candidate
@@ -84,18 +84,18 @@
                                                  :user/date-updated date-registered}))
 
        (when (= "EMPLOYER" address-owner)
-         (<? (ethlance-db/insert-row! conn :Employer {:user/address address
+         (<? (ethlance-db/insert-row! conn :Employer {:user/id address
                                                       :employer/bio bio
                                                       :employer/professional-title professional-title})))
 
        (when (= "CANDIDATE" address-owner)
-         (<? (ethlance-db/insert-row! conn :Candidate {:user/address address
+         (<? (ethlance-db/insert-row! conn :Candidate {:user/id address
                                                        :candidate/rate (rand-int 200)
                                                        :candidate/rate-currency-id currency
                                                        :candidate/bio bio
                                                        :candidate/professional-title professional-title})))
        (when (= "ARBITER" address-owner)
-         (<? (ethlance-db/insert-row! conn :Arbiter {:user/address address
+         (<? (ethlance-db/insert-row! conn :Arbiter {:user/id address
                                                      :arbiter/bio bio
                                                      :arbiter/professional-title professional-title
                                                      :arbiter/fee (rand-int 200)
@@ -145,7 +145,7 @@
                              :ethlance-job/bid-option 1}]
        (<? (ethlance-db/add-job conn (merge job ethlance-job)))
        (<? (ethlance-db/insert-row! conn :JobCreator {:job/id job-id
-                                                      :user/address employer}))))))
+                                                      :user/id employer}))))))
 
 (defn generate-job-arbiters [conn job-ids [_ _ arbiter]]
   (safe-go
@@ -154,7 +154,7 @@
            fee (rand-int 200)
            fee-currency-id (rand-nth ["EUR" "USD"])
            arbiter {:job/id job-id
-                    :user/address arbiter
+                    :user/id arbiter
                     :job-arbiter/fee fee
                     :job-arbiter/fee-currency-id fee-currency-id
                     :job-arbiter/status status}]
@@ -242,7 +242,7 @@
                                                           :job-story-message/type :feedback
                                                           :job-story/id story-id
                                                           :feedback/rating (rand-int 5)
-                                                          :user/address candidate})))
+                                                          :user/id candidate})))
 
      ;; feedback from the candidate to the employer
      (<? (ethlance-db/add-message conn (generate-message {:message/creator candidate
@@ -250,7 +250,7 @@
                                                           :job-story-message/type :feedback
                                                           :job-story/id story-id
                                                           :feedback/rating (rand-int 5)
-                                                          :user/address employer}))))))
+                                                          :user/id employer}))))))
 (defn generate-dev-data
   ([conn] (generate-dev-data conn {}))
   ([conn provided-addresses]

--- a/server/src/tests/graphql/resolvers_test.cljs
+++ b/server/src/tests/graphql/resolvers_test.cljs
@@ -70,22 +70,21 @@
                  _ (<! (ethlance-db/ready-state?))
                  conn (<? (async-db/get-connection))
                  users-addresses (into {} (map user-address-pairs ["CANDIDATE" "EMPLOYER" "ARBITER"]))
-                 _ (println "users-addresses" users-addresses)
                  _ (<! (generator/generate-dev-data conn users-addresses))
                  user-query (<! (run-query {:url api-endpoint
                                             :access-token access-token
-                                            :query [:user {:user/address (users-addresses "EMPLOYER")}
-                                                    [:user/address]]}))
+                                            :query [:user {:user/id (users-addresses "EMPLOYER")}
+                                                    [:user/id]]}))
 
                  user-search-query (<! (run-query {:url api-endpoint
                                                    :access-token access-token
                                                    :query [:user-search {:offset 0 :limit 3}
                                                            [:total-count
-                                                            [:items [:user/address]]]]}))
+                                                            [:items [:user/id]]]]}))
                  candidate-query (<! (run-query {:url api-endpoint
                                                  :access-token access-token
-                                                 :query [:candidate {:user/address (users-addresses "CANDIDATE")}
-                                                         [:user/address
+                                                 :query [:candidate {:user/id (users-addresses "CANDIDATE")}
+                                                         [:user/id
                                                           [:candidate/feedback [:total-count
                                                                                 [:items
                                                                                  [:job/id
@@ -98,20 +97,20 @@
                                                            :access-token access-token
                                                            :query [:candidate-search {:skills-or ["Clojure" "Travis"]}
                                                                    [:total-count
-                                                                    [:items [:user/address
+                                                                    [:items [:user/id
                                                                              :candidate/skills]]]]}))
 
                  candidate-search-query-and (<! (run-query {:url api-endpoint
                                                             :access-token access-token
                                                             :query [:candidate-search {:skills-and ["Clojure" "Java"]}
                                                                     [:total-count
-                                                                     [:items [:user/address
+                                                                     [:items [:user/id
                                                                               :candidate/skills]]]]}))
 
                  employer-query (<! (run-query {:url api-endpoint
                                                 :access-token access-token
-                                                :query [:employer {:user/address (users-addresses "EMPLOYER")}
-                                                        [:user/address
+                                                :query [:employer {:user/id (users-addresses "EMPLOYER")}
+                                                        [:user/id
                                                          [:employer/feedback [:total-count
                                                                               [:items
                                                                                [:job/id
@@ -122,8 +121,8 @@
 
                  arbiter-query (<! (run-query {:url api-endpoint
                                                :access-token access-token
-                                               :query [:arbiter {:user/address (users-addresses "ARBITER")}
-                                                       [:user/address
+                                               :query [:arbiter {:user/id (users-addresses "ARBITER")}
+                                                       [:user/id
                                                         [:arbiter/feedback [:total-count
                                                                             [:items
                                                                              [:job/id
@@ -187,12 +186,12 @@
                                                         :invoice/id
                                                         :invoice/amount-paid]]}))]
 
-             (is (= (users-addresses "EMPLOYER") (-> user-query :data :user :user/address str/trim)))
+             (is (= (users-addresses "EMPLOYER") (-> user-query :data :user :user/id str/trim)))
 
              (is (= 3 (-> user-search-query :data :user-search :total-count)))
              (is (= 3 (-> user-search-query :data :user-search :items count)))
 
-             (is (= (users-addresses "CANDIDATE") (-> candidate-query :data :candidate :user/address str/trim)))
+             (is (= (users-addresses "CANDIDATE") (-> candidate-query :data :candidate :user/id str/trim)))
              (is (= 5 (-> candidate-query :data :candidate :candidate/feedback :total-count)))
              (is (= 5 (-> candidate-query :data :candidate :candidate/feedback :items count)))
              (is (= "Employer" (-> candidate-query :data :candidate :candidate/feedback :items first :feedback/from-user-type)))

--- a/shared/src/ethlance/shared/contract_constants.cljs
+++ b/shared/src/ethlance/shared/contract_constants.cljs
@@ -6,7 +6,6 @@
   (get token-types (keyword type) :not-found))
 
 (defn enum-val->token-type [enum-val]
-  (println ">>> enum-val->token-type" enum-val (type enum-val))
   (get (clojure.set/map-invert token-types) enum-val :not-found))
 
 (def operation-type {:one-step-job-creation 0 :two-step-job-creation 1 :add-funds 2})

--- a/shared/src/ethlance/shared/graphql/schema.cljs
+++ b/shared/src/ethlance/shared/graphql/schema.cljs
@@ -27,10 +27,10 @@
 
   type Query {
 
-    user(user_address : ID!): User
+    user(user_id : ID!): User
 
     userSearch(
-      user_address: ID,
+      user_id: ID,
       user_name: String,
       orderBy: UserListOrderBy
       orderDirection: OrderDirection,
@@ -38,10 +38,10 @@
       offset: Int,
     ): UserList
 
-    candidate(user_address: ID!): Candidate
+    candidate(user_id: ID!): Candidate
 
     candidateSearch(
-      user_address: ID,
+      user_id: ID,
       categoriesAnd: [String],
       categoriesOr: [String],
       skillsAnd: [String],
@@ -53,10 +53,10 @@
       offset: Int,
     ): CandidateList
 
-    employer(user_address : ID!): Employer
+    employer(user_id : ID!): Employer
 
     employerSearch(
-      user_address: ID,
+      user_id: ID,
       professionalTitle: String,
       orderBy: EmployerListOrderBy,
       orderDirection: OrderDirection,
@@ -64,10 +64,10 @@
       offset: Int,
     ): EmployerList
 
-    arbiter(user_address : ID!): Arbiter
+    arbiter(user_id : ID!): Arbiter
 
     arbiterSearch(
-      user_address: ID,
+      user_id: ID,
       orderBy: ArbiterListOrderBy,
       orderDirection: OrderDirection,
       limit: Int,
@@ -97,7 +97,7 @@
   # Input types
 
   input EmployerInput {
-    user_address: ID!
+    user_id: ID!
     user_email: String!
     user_name: String!
     user_profileImage: String
@@ -109,7 +109,7 @@
   }
 
   input CandidateInput {
-    user_address: ID!
+    user_id: ID!
     user_email: String!
     user_name: String!
     user_profileImage: String
@@ -125,7 +125,7 @@
   }
 
   input ArbiterInput {
-    user_address: ID!
+    user_id: ID!
     user_email: String!
     user_name: String!
     user_profileImage: String
@@ -139,12 +139,12 @@
   }
 
   input githubSignUpInput {
-   user_address: ID!
+   user_id: ID!
    code: String!
   }
 
   input linkedinSignUpInput {
-   user_address: ID!
+   user_id: ID!
    code: String!
    redirectUri: String!
   }
@@ -177,11 +177,11 @@
 
   type signInPayload {
     jwt: String!
-    user_address: String!
+    user_id: String!
   }
 
   type updateCandidatePayload {
-    user_address: ID!
+    user_id: ID!
     user_dateUpdated: Date!
     user_profileImage: String
     user_githubUsername: String
@@ -190,7 +190,7 @@
   }
 
   type updateEmployerPayload {
-    user_address: ID!
+    user_id: ID!
     user_dateUpdated: Date!
     user_profileImage: String
     user_githubUsername: String
@@ -199,7 +199,7 @@
   }
 
   type updateArbiterPayload {
-    user_address: ID!
+    user_id: ID!
     user_dateUpdated: Date!
     user_profileImage: String
     user_githubUsername: String
@@ -208,7 +208,7 @@
   }
 
   type githubSignUpPayload {
-    user_address: ID!
+    user_id: ID!
     user_name: String
     user_githubUsername: String
     user_email: String
@@ -216,7 +216,7 @@
   }
 
   type linkedinSignUpPayload {
-    user_address: ID!
+    user_id: ID!
     user_name: String
     user_linkedinUsername: String
     user_email: String
@@ -228,7 +228,7 @@
   type User {
 
     \"Ethereum Address Corresponding to this Registered User.\"
-    user_address: ID
+    user_id: ID
 
     \"Two Letter Country Code\"
     user_country: String
@@ -281,7 +281,7 @@
 
   type Candidate {
     \"User ID for the given candidate\"
-    user_address: ID
+    user_id: ID
     user: User
 
     \"Auto Biography written by the Candidate\"
@@ -331,7 +331,7 @@
 
   type Employer {
     \"User ID for the given employer\"
-    user_address: ID
+    user_id: ID
     user: User
 
     \"Auto Biography written by the Employer\"
@@ -369,7 +369,7 @@
   # Arbiter Types
 
   type Arbiter {
-    user_address: ID
+    user_id: ID
     user: User
     arbiter_dateRegistered: Date
     arbiter_professionalTitle: String
@@ -381,7 +381,20 @@
       limit: Int,
       offset: Int
     ): FeedbackList
-    arbiter_jobStories: JobStoryList
+    arbitrations: ArbitrationList
+  }
+
+  type Arbitration {
+    user_id: ID
+    job_id: String
+    job: Job
+  }
+
+  type ArbitrationList  {
+    items: [Arbitration]
+    totalCount: Int
+    endCursor: String
+    hasNextPage: Boolean
   }
 
   type ArbiterList  {
@@ -407,8 +420,7 @@
   # Job Types
 
   type Job {
-    job_id: Int
-    job_contract: ID
+    job_id: ID
     job_title: String
     job_description: String
     job_requiredSkills: [String]
@@ -456,9 +468,8 @@
 
   type JobStory {
     jobStory_id: ID
-    job_id: Int
+    job_id: String
     job: Job
-    job_contract: String
     candidate: Candidate
     jobStory_status: Keyword
     jobStory_candidate: String

--- a/shared/src/ethlance/shared/graphql_mutations_spec.cljs
+++ b/shared/src/ethlance/shared/graphql_mutations_spec.cljs
@@ -39,7 +39,7 @@
 
 
  :mutation/update-job
- {:job/address "address"
+ {:job/id "address"
   :job/title "string, max 100 chars"
   :job/description "string, max 5000 chars"
   :job/category "one of ethlance.shared.constants/categories"
@@ -51,24 +51,24 @@
 
 
  :mutation/add-job-invitation
- {:job/address "address"
-  :user/address "address"
+ {:job/id "address"
+  :user/id "address"
   :message/text "string, max 5000 chars"}
 
  :mutation/add-job-application
- {:job/address "address"
+ {:job/id "address"
   :message/text "string, max 5000 chars"}
 
  :mutation/add-job-message
- {:job/address "address"
+ {:job/id "address"
   :message/text "string, max 5000 chars"}
 
  :mutation/add-job-feedback
- {:job/address "address"
+ {:job/id "address"
   :message/text "string, max 5000 chars"}
 
  :mutation/close-job
- {:job/address "address"}
+ {:job/id "address"}
 
  :mutation/github-sign-up
  ;; Already implemented

--- a/shared/src/ethlance/shared/spec.cljs
+++ b/shared/src/ethlance/shared/spec.cljs
@@ -23,7 +23,7 @@
 (s/def :user/github-code string?)
 (s/def :user/github-username (s/nilable string?))
 (def ethereum-address-pattern #"^0x([A-Fa-f0-9]{40})$")
-(s/def :user/address #(re-matches ethereum-address-pattern %))
+(s/def :user/id #(re-matches ethereum-address-pattern %))
 (s/def :user/linkedin-code string?)
 (s/def :user/linkedin-redirect-uri string?)
 (s/def :user/is-registered-candidate boolean?)

--- a/ui/src/ethlance/ui/component/profile_image.cljs
+++ b/ui/src/ethlance/ui/component/profile_image.cljs
@@ -1,4 +1,6 @@
-(ns ethlance.ui.component.profile-image)
+(ns ethlance.ui.component.profile-image
+  (:require
+    [ethlance.ui.util.urls :as util.urls]))
 
 (def placeholder-image-url "/images/avatar-placeholder.png")
 
@@ -21,7 +23,8 @@
                     :small " small "
                     :normal ""
                     :large " large "
-                    "")]
+                    "")
+        src-url (util.urls/ipfs-hash->gateway-url src)]
     [:div.ethlance-profile-image
      {:class size-class}
-     [:img {:src (or src placeholder-image-url)}]]))
+     [:img {:src (or src-url placeholder-image-url)}]]))

--- a/ui/src/ethlance/ui/event/sign_in.cljs
+++ b/ui/src/ethlance/ui/event/sign_in.cljs
@@ -47,7 +47,7 @@
                  "mutation SignIn($dataSignature: String!, $data: String!) {
                     signIn(dataSignature: $dataSignature, data: $data) {
                       jwt
-                      user_address
+                      user_id
                     }
                  }"
                  :variables {:dataSignature data-signature

--- a/ui/src/ethlance/ui/graphql.cljs
+++ b/ui/src/ethlance/ui/graphql.cljs
@@ -129,9 +129,9 @@
   (reduce-handlers cofx values))
 
 (defmethod handler :user
-  [{:keys [db]} _ {:user/keys [address] :as user}]
+  [{:keys [db]} _ {:user/keys [id] :as user}]
   (log/debug "user handler" user)
-  {:db (assoc-in db [:users address] user)})
+  {:db (assoc-in db [:users id] user)})
 
 (defn- merge-in-changed-parts
   "Useful in cases when app-db key can get new data from
@@ -176,7 +176,7 @@
 (defmethod handler :update-candidate
   [{:keys [db]} _ {user-date-updated :user/date-updated
                    candidate-date-updated :candidate/date-updated
-                   address :user/address
+                   address :user/id
                    :as candidate}]
   (log/debug "update-candidate handler" candidate)
   {:db (-> db
@@ -186,7 +186,7 @@
 (defmethod handler :update-employer
   [{:keys [db]} _ {user-date-updated :user/date-updated
                    employer-date-updated :employer/date-updated
-                   address :user/address
+                   address :user/id
                    :as employer}]
   (log/debug "update-employer handler" employer)
   {:db (-> db
@@ -196,7 +196,7 @@
 (defmethod handler :update-arbiter
   [{:keys [db]} _ {user-date-updated :user/date-updated
                    arbiter-date-updated :arbiter/date-updated
-                   address :user/address
+                   address :user/id
                    :as arbiter}]
   (log/debug "update-arbiter handler" arbiter)
   {:db (-> db

--- a/ui/src/ethlance/ui/page/arbiters.cljs
+++ b/ui/src/ethlance/ui/page/arbiters.cljs
@@ -87,8 +87,8 @@
    [cf-arbiter-search-filter]])
 
 (defn c-arbiter-element
-  [{:keys [:user/address]}]
-  [:div.arbiter-element {:on-click #(re/dispatch [::router-events/navigate :route.user/profile {:address address} {}])}
+  [{:keys [:user/id]}]
+  [:div.arbiter-element {:on-click #(re/dispatch [::router-events/navigate :route.user/profile {:address id} {}])}
    [:div.profile
     [:div.profile-image [c-profile-image {}]]
     [:div.name "Brian Curran"]

--- a/ui/src/ethlance/ui/page/candidates.cljs
+++ b/ui/src/ethlance/ui/page/candidates.cljs
@@ -75,10 +75,10 @@
    [cf-candidate-search-filter]])
 
 (defn c-candidate-element
-  [{:keys [:user/address
+  [{:keys [:user/id
            :candidate/professional-title
            :candidate/skills]}]
-  [:div.candidate-element {:on-click #(re/dispatch [::router-events/navigate :route.user/profile {:address address} {}])}
+  [:div.candidate-element {:on-click #(re/dispatch [::router-events/navigate :route.user/profile {:address id} {}])}
    [:div.profile
     [:div.profile-image [c-profile-image {}]]
     [:div.name "Brian Curran"]

--- a/ui/src/ethlance/ui/page/employers.cljs
+++ b/ui/src/ethlance/ui/page/employers.cljs
@@ -97,7 +97,7 @@
            [[:employer-search
              {:limit @*limit
               :offset @*offset}
-             [[:items [:user/address
+             [[:items [:user/id
                        :employer/bio
                        :employer/professional-title]]
               :total-count

--- a/ui/src/ethlance/ui/page/job_detail.cljs
+++ b/ui/src/ethlance/ui/page/job_detail.cljs
@@ -1,5 +1,6 @@
 (ns ethlance.ui.page.job-detail
   (:require [district.ui.component.page :refer [page]]
+            [district.format :as format]
             [ethlance.ui.component.button :refer [c-button c-button-label]]
             [ethlance.ui.component.carousel
              :refer
@@ -40,9 +41,9 @@
            :disabled disabled?
            :value @token-amount
            :on-change #(re/dispatch [:page.job-detail/set-proposal-token-amount (js/parseFloat %)])}]
-         [:div
+         [:a {:href (token-utils/address->token-info-url token-address) :target "_blank"}
          [:label token-symbol]
-         [:label (str "(" token-name ")")]]]))))
+         [:label (str "(" (or token-name (name token-type)) ")")]]]))))
 
 (defmethod page :route.job/detail []
   (fn []
@@ -51,7 +52,6 @@
           job-query "query ($contract: ID!) {
                    job(contract: $contract) {
                      job_id
-                     job_contract
                      job_title
                      job_description
                      job_requiredSkills
@@ -70,14 +70,14 @@
 
                      job_employer(contract: $contract) {
                        employer_rating
-                       user_address
+                       user_id
                        user {user_country user_name user_profileImage}
                      }
                      job_arbiter(contract: $contract) {
                        arbiter_rating
                        arbiter_fee
                        arbiter_feeCurrencyId
-                       user_address
+                       user_id
                        user {user_country user_name user_profileImage}
                      }
                   }
@@ -98,13 +98,13 @@
           *required-skills (:job/required-skills results)
 
           *employer-name (get-in results [:job/employer :user :user/name])
-          *employer-address (get-in results [:job/employer :user/address])
+          *employer-address (get-in results [:job/employer :user/id])
           *employer-rating (get-in results [:job/employer :employer/rating])
           *employer-country (get-in results [:job/employer :user :user/country])
           *employer-profile-image (get-in results [:job/employer :user :user/profile-image])
 
           *arbiter-name (get-in results [:job/arbiter :user :user/name])
-          *arbiter-address (get-in results [:job/arbiter :user/address])
+          *arbiter-address (get-in results [:job/arbiter :user/id])
           *arbiter-rating (get-in results [:job/arbiter :arbiter/rating])
           *arbiter-country (get-in results [:job/arbiter :user :user/country])
           *arbiter-profile-image (get-in results [:job/arbiter :user :user/profile-image])
@@ -181,7 +181,7 @@
                        [[:span (if (:current-user? proposal) "⭐" "")]
                         [:span (:candidate-name proposal)]
                         [:span (:rate proposal)]
-                        [:span (millis->relative-time (:created-at proposal))]
+                        [:span (format/time-ago (new js/Date (:created-at proposal)))]
                         [:span (:status proposal)]])
                      @proposals))]
         [:div.button-listing

--- a/ui/src/ethlance/ui/page/job_detail/events.cljs
+++ b/ui/src/ethlance/ui/page/job_detail/events.cljs
@@ -49,8 +49,8 @@
                        jobStory_proposalRate
                        jobStory_dateCreated
                        jobStory_candidate
-                       job_contract
-                       candidate {user {user_name user_address}}
+                       job_id
+                       candidate {user {user_name user_id}}
                        jobStory_proposalMessage {message_id message_type message_text message_creator}
                      }}"
                    :variables {:input proposal}}]})))
@@ -72,8 +72,8 @@
                        jobStory_proposalRate
                        jobStory_dateCreated
                        jobStory_candidate
-                       job_contract
-                       candidate {user {user_name user_address}}
+                       job_id
+                       candidate {user {user_name user_id}}
                        jobStory_proposalMessage {message_id message_type message_text message_creator}
                      }}"
                    :variables {:jobStory_id job-story-id}}]})))
@@ -91,12 +91,12 @@
                    "query JobStoriesForProposal($jobContract: ID) {
                      jobStoryList(jobContract: $jobContract) {
                        jobStory_id
-                       job_contract
+                       job_id
                        jobStory_status
                        jobStory_proposalRate
                        jobStory_dateCreated
                        jobStory_candidate
-                       candidate {user {user_name user_address}}
+                       candidate {user {user_name user_id}}
                        jobStory_proposalMessage {message_id message_type message_text message_creator}
                      }}"
                    :variables {:jobContract contract}}]})))

--- a/ui/src/ethlance/ui/page/job_detail/subscriptions.cljs
+++ b/ui/src/ethlance/ui/page/job_detail/subscriptions.cljs
@@ -17,14 +17,14 @@
 (re/reg-sub
   :page.job-detail/all-proposals
   (fn [db [_ queried-job-contract]]
-    (let [current-user-address (get-in db [:active-session :user/address])
+    (let [current-user-address (get-in db [:active-session :user/id])
           contract-from-db (get-in db [:district.ui.router :active-page :params :contract])
           contract (or queried-job-contract contract-from-db)
-          stories (filter #(= contract (:job/contract %)) (vals (:job-stories db)))]
+          stories (filter #(= contract (:job/id %)) (vals (:job-stories db)))]
       (->> stories
            (map (fn [story]
                   {:current-user? (= (clojure.string/lower-case current-user-address)
-                                     (clojure.string/lower-case (get-in story [:candidate :user :user/address])))
+                                     (clojure.string/lower-case (get-in story [:candidate :user :user/id])))
                    :job-story/id (:job-story/id story)
                    :candidate-name (get-in story [:candidate :user :user/name])
                    :rate (get-in story [:job-story/proposal-rate])

--- a/ui/src/ethlance/ui/page/new_job/events.cljs
+++ b/ui/src/ethlance/ui/page/new_job/events.cljs
@@ -44,7 +44,6 @@
 (re/reg-event-db
   :page.new-job/auto-fill-form
   (fn [db]
-    (println ">>> :page.new-job/auto-fill-form")
     (assoc-in db [state-key] state-default)))
 
 (re/reg-event-fx :page.new-job/initialize-page initialize-page)
@@ -89,7 +88,6 @@
   (fn [{:keys [db]}]
     (let [db-job (get-in db [state-key])
           ipfs-job (reduce-kv (partial db-job->ipfs-job db-job) {} db->ipfs-mapping)]
-      (println ">>> NEW job going to IPFS" ipfs-job)
       {:ipfs/call {:func "add"
                    :args [(js/Blob. [ipfs-job])]
                    :on-success [:job-to-ipfs-success]
@@ -146,7 +144,6 @@
           invited-arbiters [] ; TODO: implement
           ipfs-response (get-in event [:event 1])
           ipfs-hash (base58->hex (get-in event [1 :Hash]))]
-      (println ">>> dispatching web3-events/send-tx Ethlance#createJob" {:ipfs-hash (get-in event [1 :Hash])})
       {:dispatch [::web3-events/send-tx
                   {:instance (contract-queries/instance (:db cofx) :ethlance)
                    :fn :createJob
@@ -163,8 +160,13 @@
 
 ; TODO: fix event/callback names in README (they don't have on-<...> prefix)
 ;         https://github.com/district0x/re-frame-web3-fx#usage
-(re/reg-event-fx :tx-hash (fn [db event]         (println ">>>>>>!!!!! tx-hash" event)))
-(re/reg-event-fx :web3-tx-localstorage (fn [db event]         (println ">>>>>>!!!!! web3-tx-localstorage" event)))
+(re/reg-event-fx
+  :tx-hash
+  (fn [db event] (println ">>> ethlance.ui.page.new-job.events :tx-hash" event)))
+
+(re/reg-event-fx
+  :web3-tx-localstorage
+  (fn [db event] (println ">>> ethlance.ui.page.new-job.events :web3-tx-localstorage" event)))
 
 (re/reg-event-db
   :create-job-tx-success

--- a/ui/src/ethlance/ui/page/profile/events.cljs
+++ b/ui/src/ethlance/ui/page/profile/events.cljs
@@ -23,9 +23,9 @@
   (fn [coeff _val]
     (let [
           query "query ($address: ID!) {
-                  candidate(user_address: $address) {user_address candidate_feedback {items {feedback_rating feedback_text feedback_fromUser {user_name}} totalCount}}
-                  employer(user_address: $address) {user_address employer_feedback {items {feedback_rating feedback_text feedback_fromUser {user_name}} totalCount}}
-                  arbiter(user_address: $address) {user_address arbiter_feedback {items {feedback_rating feedback_text feedback_fromUser {user_name}} totalCount}}
+                  candidate(user_id: $address) {user_id candidate_feedback {items {feedback_rating feedback_text feedback_fromUser {user_name}} totalCount}}
+                  employer(user_id: $address) {user_id employer_feedback {items {feedback_rating feedback_text feedback_fromUser {user_name}} totalCount}}
+                  arbiter(user_id: $address) {user_id arbiter_feedback {items {feedback_rating feedback_text feedback_fromUser {user_name}} totalCount}}
                 }"
           user-address (-> coeff :db active-page-params :address)]
       {:dispatch [::graphql/query {:query query :variables {:address user-address}}]})))

--- a/ui/src/ethlance/ui/page/sign_up/events.cljs
+++ b/ui/src/ethlance/ui/page/sign_up/events.cljs
@@ -48,8 +48,8 @@
     (let [user-address (accounts-queries/active-account db)]
       {:dispatch [::graphql/query {:query
                                    "query InitialQuery($address: ID!) {
-                                      user(user_address: $address) {
-                                        user_address
+                                      user(user_id: $address) {
+                                        user_id
                                         user_name
                                         user_email
                                         user_githubUsername
@@ -58,8 +58,8 @@
                                         user_languages
                                         user_profileImage
                                       }
-                                      candidate(user_address: $address) {
-                                        user_address
+                                      candidate(user_id: $address) {
+                                        user_id
                                         candidate_professionalTitle
                                         candidate_rate
                                         candidate_rateCurrencyId
@@ -67,13 +67,13 @@
                                         candidate_bio
                                         candidate_categories
                                       }
-                                      employer(user_address: $address) {
-                                        user_address
+                                      employer(user_id: $address) {
+                                        user_id
                                         employer_professionalTitle
                                         employer_bio
                                       }
-                                      arbiter(user_address: $address) {
-                                        user_address
+                                      arbiter(user_id: $address) {
+                                        user_id
                                         arbiter_bio
                                         arbiter_professionalTitle
                                         arbiter_fee
@@ -98,14 +98,14 @@
       {:dispatch [::graphql/query {:query
                                    "mutation GithubSignUp($githubSignUpInput: githubSignUpInput!) {
                                       githubSignUp(input: $githubSignUpInput) {
-                                        user_address
+                                        user_id
                                         user_name
                                         user_githubUsername
                                         user_email
                                         user_country
                                     }
                                   }"
-                                   :variables {:githubSignUpInput {:code code :user_address user-address}}
+                                   :variables {:githubSignUpInput {:code code :user_id user-address}}
                                    :on-success #(>evt [::unregister-initial-query-forwarder])}]})))
 
 
@@ -126,14 +126,14 @@
       {:dispatch [::graphql/query {:query
                                    "mutation LinkedinSignUp($linkedinSignUpInput: linkedinSignUpInput!) {
                                       linkedinSignUp(input: $linkedinSignUpInput) {
-                                        user_address
+                                        user_id
                                         user_name
                                         user_linkedinUsername
                                         user_email
                                         user_country
                                     }
                                   }"
-                                   :variables {:linkedinSignUpInput {:code code :user_address user-address :redirectUri redirect-uri}}
+                                   :variables {:linkedinSignUpInput {:code code :user_id user-address :redirectUri redirect-uri}}
                                    :on-success #(>evt [::unregister-initial-query-forwarder])}]})))
 
 (re/reg-event-fx
@@ -166,13 +166,13 @@
       {:dispatch [::graphql/query {:query
                                    "mutation UpdateCandidate($candidateInput: CandidateInput!) {
                                       updateCandidate(input: $candidateInput) {
-                                        user_address
+                                        user_id
                                         user_profileImage
                                         user_dateUpdated
                                         candidate_dateUpdated
                                     }
                                   }"
-                                   :variables {:candidateInput {:user_address user-address
+                                   :variables {:candidateInput {:user_id user-address
                                                                 :user_email email
                                                                 :user_name name
                                                                 :user_country country
@@ -202,13 +202,13 @@
       {:dispatch [::graphql/query {:query
                                    "mutation UpdateEmployer($employerInput: EmployerInput!) {
                                       updateEmployer(input: $employerInput) {
-                                        user_address
+                                        user_id
                                         user_profileImage
                                         user_dateUpdated
                                         employer_dateUpdated
                                     }
                                   }"
-                                   :variables {:employerInput {:user_address user-address
+                                   :variables {:employerInput {:user_id user-address
                                                                :user_email email
                                                                :user_name name
                                                                :user_githubUsername github-username
@@ -236,13 +236,13 @@
       {:dispatch [::graphql/query {:query
                                    "mutation UpdateArbiter($arbiterInput: ArbiterInput!) {
                                       updateArbiter(input: $arbiterInput) {
-                                        user_address
+                                        user_id
                                         user_profileImage
                                         user_dateUpdated
                                         arbiter_dateUpdated
                                     }
                                   }"
-                                   :variables {:arbiterInput {:user_address user-address
+                                   :variables {:arbiterInput {:user_id user-address
                                                               :user_email email
                                                               :user_name name
                                                               :user_githubUsername github-username

--- a/ui/src/ethlance/ui/page/sign_up/subscriptions.cljs
+++ b/ui/src/ethlance/ui/page/sign_up/subscriptions.cljs
@@ -2,6 +2,7 @@
   (:require
     [ethlance.ui.page.sign-up.events :as sign-up.events]
     [ethlance.ui.subscriptions :as ethlance-subs]
+    [ethlance.ui.util.urls :as util.urls]
     [re-frame.core :as re]))
 
 
@@ -10,18 +11,13 @@
   (fn [db]
     (get-in db [sign-up.events/state-key :user/profile-image])))
 
-(defn ipfs-hash->gateway-url
- [ipfs-hash]
- ; This URL should come from configuration
- (str "http://ipfs.localhost:8080/ipfs/" ipfs-hash))
-
 (re/reg-sub
   :page.sign-up/update-user-profile-image
   (fn [query-v]
     [(re/subscribe [:page.sign-up/user-profile-image])
      (re/subscribe [::ethlance-subs/active-user])])
   (fn [[image-from-form active-user] query]
-    (ipfs-hash->gateway-url (or image-from-form (:user/profile-image active-user)))))
+    (util.urls/ipfs-hash->gateway-url (or image-from-form (:user/profile-image active-user)))))
 
 (re/reg-sub
   :page.sign-up/form

--- a/ui/src/ethlance/ui/subscriptions.cljs
+++ b/ui/src/ethlance/ui/subscriptions.cljs
@@ -33,8 +33,8 @@
   :<- [::active-session]
   :<- [::accounts-subs/active-account]
   (fn [[active-session active-account]]
-    (and (cljs-utils/not-nil? (:user/address active-session))
-         (= (:user/address active-session) active-account))))
+    (and (cljs-utils/not-nil? (:user/id active-session))
+         (= (:user/id active-session) active-account))))
 
 
 (re/reg-sub

--- a/ui/src/ethlance/ui/util/tokens.cljs
+++ b/ui/src/ethlance/ui/util/tokens.cljs
@@ -1,0 +1,7 @@
+(ns ethlance.ui.util.tokens
+  (:require
+    [re-frame.core :as re]
+    [cljs-web3-next.eth :as w3-eth]))
+
+(defn address->token-info-url [address]
+  (str "https://ethplorer.io/address/" address))

--- a/ui/src/ethlance/ui/util/urls.cljs
+++ b/ui/src/ethlance/ui/util/urls.cljs
@@ -1,0 +1,16 @@
+(ns ethlance.ui.util.urls)
+
+(defn ipfs-hash->gateway-url
+ [ipfs-hash]
+ ;TODO: This URL should come from configuration
+ (cond
+   (= nil ipfs-hash)
+   ipfs-hash
+
+   (or
+     (clojure.string/starts-with? ipfs-hash "http")
+     (clojure.string/starts-with? ipfs-hash "/"))
+   ipfs-hash
+
+   :else
+   (str "http://ipfs.localhost:8080/ipfs/" ipfs-hash)))


### PR DESCRIPTION
Because these addresses uniquely identify these models (Job, User), the numeric (serial) ID column is redundant. Instead this change makes the primary key of these to be the address column (still named .../id)